### PR TITLE
Use Buildkite and Docker for CI

### DIFF
--- a/.buildkite/nodeTests
+++ b/.buildkite/nodeTests
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+npm run build && npm run test-node

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,17 @@
+steps:
+  - name: ":docker: :package:"
+    plugins:
+      docker-compose#v1.5.2:
+        build: mathgl
+        image-repository: 296822479253.dkr.ecr.us-east-2.amazonaws.com/fusionjs
+  - wait
+  - name: ":eslint:"
+    command: "npm run lint"
+    plugins:
+      docker-compose#v1.5.2:
+        run: mathgl
+  - name: ":node:"
+    command: ".buildkite/nodeTests"
+    plugins:
+      docker-compose#v1.5.2:
+        run: mathgl

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,16 +2,16 @@ steps:
   - name: ":docker: :package:"
     plugins:
       docker-compose#v1.5.2:
-        build: mathgl
+        build: math-gl
         image-repository: 296822479253.dkr.ecr.us-east-2.amazonaws.com/fusionjs
   - wait
   - name: ":eslint:"
     command: "npm run lint"
     plugins:
       docker-compose#v1.5.2:
-        run: mathgl
+        run: math-gl
   - name: ":node:"
     command: ".buildkite/nodeTests"
     plugins:
       docker-compose#v1.5.2:
-        run: mathgl
+        run: math-gl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:8.9.0
+
+WORKDIR /mathgl
+
+COPY package.json yarn.lock /mathgl/
+
+RUN yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:8.9.0
 
-WORKDIR /mathgl
+WORKDIR /math-gl
 
-COPY package.json yarn.lock /mathgl/
+COPY package.json yarn.lock /math-gl/
 
 RUN yarn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
-  mathgl:
+  math-gl:
     build: .
     volumes:
-      - .:/mathgl
-      - /mathgl/node_modules/
+      - .:/math-gl
+      - /math-gl/node_modules/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+services:
+  mathgl:
+    build: .
+    volumes:
+      - .:/mathgl
+      - /mathgl/node_modules/


### PR DESCRIPTION
This is a proposal to use Buildkite for CI, which will allow for reproducible and parallel builds. Currently this will run alongside Travis while we try it out. The web platform team has had success with Buildkite, and we are willing to help folks integrate it into their workflows as we think it will bring improved productivity.

* Adds a dockerfile and docker-compose file for reproducible CI containers.
* Adds a buildkite pipeline for running linters and node tests in parallel.

Generates a build page that looks like this:

![image](https://user-images.githubusercontent.com/122602/32672155-daf1e428-c5fe-11e7-9759-f6b4cf696975.png)
