### PR TITLE
Use underscore for experimental API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ addons:
 node_js:
   - '6'
   - '8'
+  - '10'
 before_script:
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ addons:
 node_js:
   - '6'
   - '8'
-  - '10'
 before_script:
   - npm run build

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.0.0-alpha.1 - TBD
+
+- Rename experimental classes to use underscore (_).
+
 ## v1.2.1 - May 21, 2018
 
 - Add `lerp` utility function

--- a/docs/api-reference/addons/polygon.md
+++ b/docs/api-reference/addons/polygon.md
@@ -1,4 +1,6 @@
-# Polygon (Experimental)
+# \_Polygon (Experimental)
+
+> Note this class is experimental and may change or be removed in minor math.gl versions.
 
 Allows an array of points (whether closed or non-closed) to be treated as a Polygon.
 

--- a/docs/api-reference/addons/polygon.md
+++ b/docs/api-reference/addons/polygon.md
@@ -1,10 +1,16 @@
-# \_Polygon (Experimental)
+# Polygon (Experimental)
 
 > Note this class is experimental and may change or be removed in minor math.gl versions.
 
 Allows an array of points (whether closed or non-closed) to be treated as a Polygon.
 
 Implements the [Shoelace formula](https://en.wikipedia.org/wiki/Shoelace_formula) for determining the area and winding direction of an arbitrary polygon.
+
+## Usage
+
+```js
+import {_Polygon as Polygon} from 'math.gl';
+```
 
 
 ## Methods

--- a/docs/api-reference/euler.md
+++ b/docs/api-reference/euler.md
@@ -1,9 +1,9 @@
-# Euler
+# \_Euler (Experimental)
 
-> Note this class is experimental and must be imported from the `experimental` namespace.
+> Note this class is experimental and may change or be removed in minor math.gl versions.
 
 ```js
-class Euler extends MathArray extends Array
+class _Euler extends MathArray extends Array
 ```
 
 A class to handle Euler rotation. More information on rotation using a Euler vector can be found [here](https://en.wikipedia.org/wiki/Euler%27s_rotation_theorem). Generally speaking the three components of the Euler object represents the roll, pitch and yaw angles and the rotation is applied according to a specific rotation order.
@@ -12,8 +12,7 @@ A class to handle Euler rotation. More information on rotation using a Euler vec
 ## Usage
 
 ```js
-import {experimental} from 'math.gl';
-const {Euler} = experimental;
+import {_Euler as Euler} from 'math.gl'
 ```
 
 ## Constants

--- a/docs/api-reference/euler.md
+++ b/docs/api-reference/euler.md
@@ -1,9 +1,9 @@
-# \_Euler (Experimental)
+# Euler (Experimental)
 
 > Note this class is experimental and may change or be removed in minor math.gl versions.
 
 ```js
-class _Euler extends MathArray extends Array
+class Euler extends MathArray extends Array
 ```
 
 A class to handle Euler rotation. More information on rotation using a Euler vector can be found [here](https://en.wikipedia.org/wiki/Euler%27s_rotation_theorem). Generally speaking the three components of the Euler object represents the roll, pitch and yaw angles and the rotation is applied according to a specific rotation order.

--- a/docs/api-reference/pose.md
+++ b/docs/api-reference/pose.md
@@ -1,4 +1,4 @@
-# \_Pose (Experimental)
+# Pose (Experimental)
 
 > Note this class is experimental and may change or be removed in minor math.gl versions.
 
@@ -12,8 +12,7 @@ class Pose
 ## Usage
 
 ```js
-import {experimental} from 'math.gl';
-const {Pose} = experimental;
+import {_Pose as Pose} from 'math.gl';
 ```
 
 ##  Members

--- a/docs/api-reference/pose.md
+++ b/docs/api-reference/pose.md
@@ -1,4 +1,6 @@
-# Vector2
+# \_Pose (Experimental)
+
+> Note this class is experimental and may change or be removed in minor math.gl versions.
 
 A 6-degree-freedom pose (3D position and 3D rotation).
 See [Tait–Bryan angles](https://en.wikipedia.org/wiki/Euler_angles): z-y'-x"

--- a/docs/api-reference/spherical-coordinates.md
+++ b/docs/api-reference/spherical-coordinates.md
@@ -1,7 +1,6 @@
 # SphericalCoordinates
 
 > Note this class is considered experimental and must be imported from the `experimental` namespace.
-
 > This documentation is incomplete and may be incorrect
 
 ```js

--- a/docs/api-reference/spherical-coordinates.md
+++ b/docs/api-reference/spherical-coordinates.md
@@ -1,4 +1,4 @@
-# SphericalCoordinates
+# SphericalCoordinates (Experimental)
 
 > Note this class is considered experimental and must be imported from the `experimental` namespace.
 > This documentation is incomplete and may be incorrect
@@ -7,7 +7,7 @@
 class SphericalCoordinates
 ```
 
-See also [Wikipedia](https://en.wikipedia.org/wiki/Spherical_coordinate_system), [Wolfram MathWorld](http://mathworld.wolfram.com/SphericalCoordinates.html) or 
+See also [Wikipedia](https://en.wikipedia.org/wiki/Spherical_coordinate_system), [Wolfram MathWorld](http://mathworld.wolfram.com/SphericalCoordinates.html).
 
 * The poles (phi) are at the positive and negative y axis.
 * The equator starts at positive z.
@@ -57,8 +57,7 @@ Ranges
 ## Usage
 
 ```js
-import {experimental} from 'math.gl';
-const {SphericalCoordinates} = experimental;
+import {_SphericalCoordinates as SphericalCoordinates} from 'math.gl';
 ```
 
 Creating a SphericalCoordinates object

--- a/package.json
+++ b/package.json
@@ -67,8 +67,6 @@
     "babel-plugin-istanbul": "^4.1.1",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-version-inline": "^1.0.0",
-    "babel-preset-minify": "0.4.0-alpha.caaefb4c",
-    "benchmark": "^2.1.3",
     "coveralls": "^2.13.0",
     "eslint": "^3.0.0",
     "eslint-config-prettier": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "math.gl",
   "description": "Array-based 3D Math Classes optimized for WebGL applications",
   "license": "MIT",
-  "version": "1.2.1",
+  "version": "2.0.0-alpha.1",
   "keywords": [
     "webgl",
     "javascript",

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,6 @@ export {
 } from './lib/common';
 
 export {default as _SphericalCoordinates} from './spherical-coordinates';
-import {default as _Pose} from './pose';
-import {default as _Euler} from './euler';
-import {default as _Polygon} from './addons/polygon';
+export {default as _Pose} from './pose';
+export {default as _Euler} from './euler';
+export {default as _Polygon} from './addons/polygon';

--- a/src/index.js
+++ b/src/index.js
@@ -46,13 +46,7 @@ export {
   equals
 } from './lib/common';
 
-import {default as SphericalCoordinates} from './spherical-coordinates';
-import {default as Pose} from './pose';
-import {default as Euler} from './euler';
-import {default as Polygon} from './addons/polygon';
-export const experimental = {
-  SphericalCoordinates,
-  Euler,
-  Pose,
-  Polygon
-};
+export {default as _SphericalCoordinates} from './spherical-coordinates';
+import {default as _Pose} from './pose';
+import {default as _Euler} from './euler';
+import {default as _Polygon} from './addons/polygon';

--- a/test/src/addons/polygon.spec.js
+++ b/test/src/addons/polygon.spec.js
@@ -22,8 +22,7 @@
 import test from 'tape-catch';
 import {tapeEquals} from 'math.gl/test/utils/tape-equals';
 
-import {configure, experimental} from 'math.gl';
-const {Polygon} = experimental;
+import {configure, _Polygon as Polygon} from 'math.gl';
 
 const TEST_CASES = [
   {

--- a/test/src/euler.spec.js
+++ b/test/src/euler.spec.js
@@ -1,5 +1,4 @@
-import {experimental} from 'math.gl';
-const {Euler} = experimental;
+import {_Euler as Euler} from 'math.gl';
 
 import test from 'tape-catch';
 

--- a/test/src/pose.spec.js
+++ b/test/src/pose.spec.js
@@ -1,6 +1,6 @@
 import test from 'tape-catch';
-import {Matrix4, Vector3, experimental, equals} from 'math.gl';
-const {Euler, Pose} = experimental;
+import {Matrix4, Vector3, equals} from 'math.gl';
+import {_Euler as Euler, _Pose as Pose} from 'math.gl';
 
 const MATRIX_TEST_CASES = [{
     TRANSFORM_A_TO_B: {

--- a/test/src/spherical-coordinates.spec.js
+++ b/test/src/spherical-coordinates.spec.js
@@ -19,8 +19,7 @@
 // THE SOFTWARE.
 
 /* eslint-disable max-statements, max-depth */
-import {experimental} from 'math.gl';
-const {SphericalCoordinates} = experimental;
+import {_SphericalCoordinates as SphericalCoordinates} from 'math.gl';
 import test from 'tape-catch';
 
 // FOR TAPE TESTING

--- a/website/src/mdRoutes.js
+++ b/website/src/mdRoutes.js
@@ -96,16 +96,16 @@ export default [{
   }, {
     name: 'Experimental API',
     children: [{
-      name: 'Euler',
+      name: '_Euler',
       markdown: require('../../docs/api-reference/euler.md')
     }, {
-      name: 'Pose',
+      name: '_Pose',
       markdown: require('../../docs/api-reference/pose.md')
     }, {
-      name: 'SphericalCoordinates',
+      name: '_SphericalCoordinates',
       markdown: require('../../docs/api-reference/spherical-coordinates.md')
     }, {
-      name: 'Polygon',
+      name: '_Polygon',
       markdown: require('../../docs/api-reference/addons/polygon.md')
     }]
   }]

--- a/website/src/mdRoutes.js
+++ b/website/src/mdRoutes.js
@@ -96,16 +96,16 @@ export default [{
   }, {
     name: 'Experimental API',
     children: [{
-      name: '_Euler',
+      name: 'Euler (Experimental)',
       markdown: require('../../docs/api-reference/euler.md')
     }, {
-      name: '_Pose',
+      name: 'Pose (Experimental)',
       markdown: require('../../docs/api-reference/pose.md')
     }, {
-      name: '_SphericalCoordinates',
+      name: 'SphericalCoordinates (Experimental)',
       markdown: require('../../docs/api-reference/spherical-coordinates.md')
     }, {
-      name: '_Polygon',
+      name: 'Polygon (Experimental)',
       markdown: require('../../docs/api-reference/addons/polygon.md')
     }]
   }]


### PR DESCRIPTION
This is an initial PR towards using `_` for marking experimental APIs. It raises a few questions:

* Should we doc these classes as `_Euler` etc?
* Or still doc them as `Euler (Experimental)` and just require that they be imported using underscore, e.g. `import {_Euler as Euler}`.

For some reason I seem to be in favor of the latter. Less impact on docs, ToCs etc.

@1chandu