### PR TITLE
Support reconstructing Pose from serialized/deserialized props

### DIFF
--- a/docs/api-reference/pose.md
+++ b/docs/api-reference/pose.md
@@ -31,11 +31,14 @@ Gets or sets rotation components respectively
 ### constructor
 
 ```
-new Pose({x, y, z, roll, pitch, yaw})
+new Pose({x, y, z, roll, pitch, yaw});
+new Pose({position, orientation});
 ```
 
  * `x`, `y`, `z` - position
  * `roll`, `pitch`, `yaw` - rotation in radians
+ * `position` - `Vector3` or array of 3 that represents the position
+ * `orientation` - `Euler` or array of 4 that represents the rotation
 
 ### getPosition
 
@@ -48,6 +51,14 @@ Returns `Vector3`.
 `pose.getOrientation()`
 
 Returns `Euler`.
+
+### equals
+
+`pose.equals(otherPose)`
+
+### exactEquals
+
+`pose.exactEquals(otherPose)`
 
 ### getTransformationMatrix
 

--- a/src/pose.js
+++ b/src/pose.js
@@ -31,9 +31,11 @@ export default class Pose {
    * pose's position and with with the defining pose's orientation
    * aligned with axis.
    */
-  constructor({x = 0, y = 0, z = 0, roll = 0, pitch = 0, yaw = 0}) {
-    this.position = new Vector3(x, y, z);
-    this.orientation = new Euler(roll, pitch, yaw, Euler.RollPitchYaw);
+  constructor({x = 0, y = 0, z = 0, roll = 0, pitch = 0, yaw = 0, position, orientation}) {
+    this.position = position ? new Vector3(position) : new Vector3(x, y, z);
+    this.orientation = orientation
+      ? new Euler(orientation, Euler.RollPitchYaw)
+      : new Euler(roll, pitch, yaw, Euler.RollPitchYaw);
   }
 
   /* eslint-disable no-multi-spaces, brace-style, no-return-assign */

--- a/src/pose.js
+++ b/src/pose.js
@@ -32,10 +32,16 @@ export default class Pose {
    * aligned with axis.
    */
   constructor({x = 0, y = 0, z = 0, roll = 0, pitch = 0, yaw = 0, position, orientation}) {
-    this.position = position ? new Vector3(position) : new Vector3(x, y, z);
-    this.orientation = orientation
-      ? new Euler(orientation, Euler.RollPitchYaw)
-      : new Euler(roll, pitch, yaw, Euler.RollPitchYaw);
+    if (Array.isArray(position) && position.length === 3) {
+      this.position = new Vector3(position);
+    } else {
+      this.position = new Vector3(x, y, z);
+    }
+    if (Array.isArray(orientation) && orientation.length === 4) {
+      this.orientation = new Euler(orientation, orientation[3]);
+    } else {
+      this.orientation = new Euler(roll, pitch, yaw, Euler.RollPitchYaw);
+    }
   }
 
   /* eslint-disable no-multi-spaces, brace-style, no-return-assign */
@@ -59,6 +65,20 @@ export default class Pose {
 
   getOrientation() {
     return this.orientation;
+  }
+
+  equals(pose) {
+    if (!pose) {
+      return false;
+    }
+    return this.position.equals(pose.position) && this.orientation.equals(pose.orientation);
+  }
+
+  exactEquals(pose) {
+    if (!pose) {
+      return false;
+    }
+    return this.position.exactEquals(pose.position) && this.orientation.exactEquals(pose.orientation);
   }
 
   /*

--- a/test/src/pose.spec.js
+++ b/test/src/pose.spec.js
@@ -58,8 +58,33 @@ const MATRIX_TEST_CASES = [{
   }
 ];
 
+function arePosesEqual(pose1, pose2) {
+  return equals(pose1.position, pose2.position) & equals(pose1.orientation, pose2.orientation);
+}
+
 test('Pose#import', t => {
   t.equals(typeof Pose, 'function');
+  t.end();
+});
+
+test('Pose#constructor', t => {
+  let pose1;
+  let pose2;
+
+  pose1 = new Pose({});
+  t.ok(pose1, 'constructed from empty props');
+
+  pose1 = new Pose(MATRIX_TEST_CASES[0].TRANSFORM_A_TO_B);
+  t.ok(pose1, 'constructed from x y z pitch roll yaw');
+
+  pose2 = new Pose(pose1);
+  t.ok(arePosesEqual(pose1, pose2), 'reconstructed from another pose');
+
+  const flattenProps = JSON.parse(JSON.stringify(pose1));
+  pose2 = new Pose(flattenProps);
+
+  t.ok(arePosesEqual(pose1, pose2), 'reconstructed from flatten props');
+
   t.end();
 });
 

--- a/test/src/pose.spec.js
+++ b/test/src/pose.spec.js
@@ -58,10 +58,6 @@ const MATRIX_TEST_CASES = [{
   }
 ];
 
-function arePosesEqual(pose1, pose2) {
-  return equals(pose1.position, pose2.position) & equals(pose1.orientation, pose2.orientation);
-}
-
 test('Pose#import', t => {
   t.equals(typeof Pose, 'function');
   t.end();
@@ -78,12 +74,12 @@ test('Pose#constructor', t => {
   t.ok(pose1, 'constructed from x y z pitch roll yaw');
 
   pose2 = new Pose(pose1);
-  t.ok(arePosesEqual(pose1, pose2), 'reconstructed from another pose');
+  t.ok(pose1.equals(pose2), 'reconstructed from another pose');
 
   const flattenProps = JSON.parse(JSON.stringify(pose1));
   pose2 = new Pose(flattenProps);
 
-  t.ok(arePosesEqual(pose1, pose2), 'reconstructed from flatten props');
+  t.ok(pose1.equals(pose2), 'reconstructed from flatten props');
 
   t.end();
 });


### PR DESCRIPTION
### Background

A `Pose` instance is serialized then deserialized when passed via `postMessage` between threads. This process removes all class methods and results in a plain object in the form of `{position: Array[3], orientation: Array[4]}`. It will be much easier to reconstruct the pose if the constructor understands this flatten format.

### Change List

- `Pose.contructor` recognizes `position` and `orientation` from props
- Tests