### PR TITLE
Decouple Quaternion from Euler to optimize tree-shaking

### DIFF
--- a/docs/api-reference/euler.md
+++ b/docs/api-reference/euler.md
@@ -59,6 +59,23 @@ rotation order in all notations
  * Number|Number[], Number, Number, Number
 
 
+### fromRollPitchYaw
+
+Common ZYX rotation order
+
+`euler.fromRollPitchYaw(roll, pitch, yaw)`
+
+
+### fromRotationMatrix
+
+`euler.fromRotationMatrix(m, order = Euler.DefaultOrder)`
+
+
+### fromQuaternion
+
+`euler.fromQuaternion(q, order)`
+
+
 ### copy
 
 If copied array does contain fourth element, preserves currently set order.
@@ -100,23 +117,6 @@ Copies the orientation element
 ### fromArray
 
 `euler.fromArray(array, offset = 0)`
-
-
-### fromRollPitchYaw
-
-Common ZYX rotation order
-
-`euler.fromRollPitchYaw(roll, pitch, yaw)`
-
-
-### fromQuaternion
-
-`euler.fromQuaternion(q, order)`
-
-
-### fromRotationMatrix
-
-`euler.fromRotationMatrix(m, order = Euler.DefaultOrder)`
 
 
 ### getRotationMatrix

--- a/src/euler.js
+++ b/src/euler.js
@@ -128,6 +128,10 @@ export default class Euler extends MathArray {
     return new Euler(roll, pitch, yaw, Euler.RollPitchYaw);
   }
 
+  // fromQuaternion(q, order) {
+  //   this._fromRotationMatrix(Matrix4.fromQuaternion(q), order);
+  //   return this.check();
+  // }
 
   // If copied array does contain fourth element, preserves currently set order
   copy(array) {
@@ -313,11 +317,6 @@ export default class Euler extends MathArray {
   // Common ZYX rotation order
   fromRollPitchYaw(roll, pitch, yaw) {
     return this.set(roll, pitch, yaw, Euler.ZYX);
-  }
-
-  fromQuaternion(q, order) {
-    this._fromRotationMatrix(Matrix4.fromQuaternion(q), order);
-    return this.check();
   }
 
   fromRotationMatrix(m, order = Euler.DefaultOrder) {

--- a/src/euler.js
+++ b/src/euler.js
@@ -110,7 +110,7 @@ export default class Euler extends MathArray {
   }
 
   fromQuaternion(quaternion) {
-    const [w, x, y, z] = quaternion;
+    const [x, y, z, w] = quaternion;
     const ysqr = y * y;
     const t0 = -2.0 * (ysqr + z * z) + 1.0;
     const t1 = +2.0 * (x * y + w * z);

--- a/src/euler.js
+++ b/src/euler.js
@@ -109,6 +109,26 @@ export default class Euler extends MathArray {
     }
   }
 
+  fromQuaternion(quaternion) {
+    const [w, x, y, z] = quaternion;
+    const ysqr = y * y;
+    const t0 = -2.0 * (ysqr + z * z) + 1.0;
+    const t1 = +2.0 * (x * y + w * z);
+    let t2 = -2.0 * (x * z - w * y);
+    const t3 = +2.0 * (y * z + w * x);
+    const t4 = -2.0 * (x * x + ysqr) + 1.0;
+
+    t2 = t2 > 1.0 ? 1.0 : t2;
+    t2 = t2 < -1.0 ? -1.0 : t2;
+
+    const roll = Math.atan2(t3, t4);
+    const pitch = Math.asin(t2);
+    const yaw = Math.atan2(t1, t0);
+
+    return new Euler(roll, pitch, yaw, Euler.RollPitchYaw);
+  }
+
+
   // If copied array does contain fourth element, preserves currently set order
   copy(array) {
     for (let i = 0; i < 3; ++i) {

--- a/src/quaternion.js
+++ b/src/quaternion.js
@@ -20,7 +20,6 @@
 
 import MathArray from './lib/math-array';
 import {checkNumber} from './lib/common';
-import Euler from './euler';
 
 import * as quat from 'gl-matrix/quat';
 
@@ -251,24 +250,5 @@ export default class Quaternion extends MathArray {
   slerp({start = IDENTITY_QUATERNION, target, ratio}) {
     quat.slerp(this, start, target, ratio);
     return this.check();
-  }
-
-  toEuler() {
-    const {w, x, y, z} = this;
-    const ysqr = y * y;
-    const t0 = -2.0 * (ysqr + z * z) + 1.0;
-    const t1 = +2.0 * (x * y + w * z);
-    let t2 = -2.0 * (x * z - w * y);
-    const t3 = +2.0 * (y * z + w * x);
-    const t4 = -2.0 * (x * x + ysqr) + 1.0;
-
-    t2 = t2 > 1.0 ? 1.0 : t2;
-    t2 = t2 < -1.0 ? -1.0 : t2;
-
-    const roll = Math.atan2(t3, t4);
-    const pitch = Math.asin(t2);
-    const yaw = Math.atan2(t1, t0);
-
-    return new Euler(roll, pitch, yaw, Euler.RollPitchYaw);
   }
 }

--- a/test/src/euler.spec.js
+++ b/test/src/euler.spec.js
@@ -13,7 +13,7 @@ test('Euler#construct and Array.isArray check', t => {
   t.end();
 });
 
-test('Euler.toQuaternion', t => {
+test('Euler#toQuaternion', t => {
   const eulers = [
     new Euler(
       90 * DEGREE_TO_RADIANS,
@@ -35,6 +35,6 @@ test('Euler.toQuaternion', t => {
     )
   ];
   const quaternions = eulers.map(e => e.toQuaternion());
-  t.ok(quaternions.every((q, i) => equals(q.toEuler(), eulers[i])));
+  t.ok(quaternions.every((q, i) => equals(new Euler().fromQuaternion(q), eulers[i])));
   t.end();
 });

--- a/test/src/euler.spec.js
+++ b/test/src/euler.spec.js
@@ -1,7 +1,32 @@
-import {_Euler as Euler, equals} from 'math.gl';
+import {_Euler as Euler, Matrix4, Quaternion, _Pose as Pose} from 'math.gl';
 import test from 'tape-catch';
+import {tapeEquals} from '../utils/tape-equals';
 
 const DEGREE_TO_RADIANS = Math.PI / 180;
+
+function extendToMatrix4(arr) {
+  const matrix4 = new Matrix4();
+  matrix4.setRowMajor(
+    arr[0],
+    arr[1],
+    arr[2],
+    0,
+    arr[3],
+    arr[4],
+    arr[5],
+    0,
+    arr[6],
+    arr[7],
+    arr[8],
+    0,
+    0,
+    0,
+    0,
+    1
+  );
+
+  return matrix4;
+}
 
 test('Euler#import', t => {
   t.equals(typeof Euler, 'function');
@@ -35,6 +60,88 @@ test('Euler#toQuaternion', t => {
     )
   ];
   const quaternions = eulers.map(e => e.toQuaternion());
-  t.ok(quaternions.every((q, i) => equals(new Euler().fromQuaternion(q), eulers[i])));
+  quaternions.every((q, i) => {
+    tapeEquals(
+      t,
+      new Euler().fromQuaternion(q, Euler.RollPitchYaw),
+      eulers[i],
+      'Euler.fromQuaternion returns correct value'
+    );
+  });
+  t.end();
+});
+
+test('Euler.fromQuaternion', t => {
+  // transformMatrix result from https://www.wolframalpha.com/input/?i=quaternion:
+  const testCases = [
+    {
+      quaternion: new Quaternion(
+        -0.49561769378289866,
+        -0.5043442292812725,
+        -0.5043442292812726,
+        0.49561769378289866
+      ),
+      transformMatrix: extendToMatrix4([
+        -0.017452406437283,
+        0.999847695156391,
+        10e-15,
+        10e-15,
+        10e-15,
+        1.0,
+        0.999847695156391,
+        0.017452406437283,
+        10e-15
+      ])
+    },
+    {
+      quaternion: new Quaternion(
+        -0.09229595564125728,
+        0.4304593345768794,
+        0.560985526796931,
+        0.7010573846499779
+      ),
+      transformMatrix: extendToMatrix4([
+        0.1e-14,
+        -0.86602540378444,
+        0.5,
+        0.70710678118655,
+        0.35355339059327,
+        0.61237243569579,
+        -0.70710678118655,
+        0.35355339059327,
+        0.61237243569579
+      ])
+    },
+    {
+      quaternion: new Quaternion(
+        -0.13640420781001386,
+        0.5381614474482503,
+        0.2687711688270994,
+        0.7871074941705494
+      ),
+      transformMatrix: extendToMatrix4([
+        0.27628863057544,
+        -0.56991857422771,
+        0.77385877998831,
+        0.27628863057544,
+        0.81831190179808,
+        0.50401411090402,
+        -0.92050485345244,
+        0.07455501408938,
+        0.38355229714425
+      ])
+    }
+  ];
+
+  const eulers = testCases.map(tc => new Euler().fromQuaternion(tc.quaternion));
+  const results = eulers.map(e => {
+    const pose = new Pose({yaw: e.yaw, pitch: e.pitch, roll: e.roll});
+    return pose.getTransformationMatrix();
+  });
+
+  results.every((result, i) =>
+    tapeEquals(t, result, testCases[i].transformMatrix, 'Euler.fromQuaternion OK')
+  );
+
   t.end();
 });

--- a/test/src/matrix4.spec.js
+++ b/test/src/matrix4.spec.js
@@ -21,22 +21,9 @@
 /* eslint-disable max-statements */
 import {Matrix4, Vector3, config} from 'math.gl';
 import test from 'tape-catch';
+import {tapeEquals} from '../utils/tape-equals';
 
 config.EPSILON = 1e-6;
-
-// FOR TAPE TESTING
-// Use tape assert to compares using a.equals(b)
-// Usage test(..., t => { tapeEquals(t, a, b, ...); });
-export function tapeEquals(t, a, b, msg, extra) {
-  /* eslint-disable no-invalid-this */
-  t._assert(a.equals(b), {
-    message: msg || 'should be equal',
-    operator: 'equal',
-    actual: a,
-    expected: b,
-    extra
-  });
-}
 
 const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 

--- a/test/src/quaternion.spec.js
+++ b/test/src/quaternion.spec.js
@@ -77,7 +77,6 @@ test('Quaternion#methods', t => {
   // t.equals(typeof q.normSq, 'function');
   t.equals(typeof q.scale, 'function');
   t.equals(typeof q.set, 'function');
-  t.equals(typeof q.toEuler, 'function');
   // t.equals(typeof q.setQuaternion, 'function');
   // t.equals(typeof q.sub, 'function');
   // t.equals(typeof q.unit, 'function');
@@ -112,76 +111,3 @@ test('Quaternion#methods', t => {
 //   t.equals(q1[3], 0.7439232829017486);
 //   t.end();
 // });
-
-test('Quaternion.toEuler', t => {
-  // transformMatrix result from https://www.wolframalpha.com/input/?i=quaternion:
-  const testCases = [
-    {
-      quaternion: new Quaternion(
-        -0.49561769378289866,
-        -0.5043442292812725,
-        -0.5043442292812726,
-        0.49561769378289866
-      ),
-      transformMatrix: extendToMatrix4([
-        -0.017452406437283,
-        0.999847695156391,
-        10e-15,
-        10e-15,
-        10e-15,
-        1.0,
-        0.999847695156391,
-        0.017452406437283,
-        10e-15
-      ])
-    },
-    {
-      quaternion: new Quaternion(
-        -0.09229595564125728,
-        0.4304593345768794,
-        0.560985526796931,
-        0.7010573846499779
-      ),
-      transformMatrix: extendToMatrix4([
-        0.1e-14,
-        -0.86602540378444,
-        0.5,
-        0.70710678118655,
-        0.35355339059327,
-        0.61237243569579,
-        -0.70710678118655,
-        0.35355339059327,
-        0.61237243569579
-      ])
-    },
-    {
-      quaternion: new Quaternion(
-        -0.13640420781001386,
-        0.5381614474482503,
-        0.2687711688270994,
-        0.7871074941705494
-      ),
-      transformMatrix: extendToMatrix4([
-        0.27628863057544,
-        -0.56991857422771,
-        0.77385877998831,
-        0.27628863057544,
-        0.81831190179808,
-        0.50401411090402,
-        -0.92050485345244,
-        0.07455501408938,
-        0.38355229714425
-      ])
-    }
-  ];
-
-  const eulers = testCases.map(t => t.quaternion.toEuler());
-  const results = eulers.map(e => {
-    const pose = new Pose({yaw: e.yaw, pitch: e.pitch, roll: e.roll});
-    return pose.getTransformationMatrix();
-  });
-
-  t.ok(results.every((result, i) => equals(result, testCases[i].transformMatrix)));
-
-  t.end();
-});

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -28,5 +28,7 @@ module.exports = env => {
     rootDir: `${__dirname}/..`,
     getAliases
   });
+  // console.log('webpack env', JSON.stringify(env));
+  // console.log('webpack config', JSON.stringify(config, null, 2));
   return config;
 };

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -28,7 +28,5 @@ module.exports = env => {
     rootDir: `${__dirname}/..`,
     getAliases
   });
-  // console.log('webpack env', JSON.stringify(env));
-  // console.log('webpack config', JSON.stringify(config, null, 2));
   return config;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,17 +875,7 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^6.1.0:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.2.tgz#caceccf474bf3fc3ce3b147443711a24063cc30d"
-  integrity sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==
-  dependencies:
-    fast-deep-equal "^2.0.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.5.5:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.7.0.tgz#e3ce7bb372d6577bb1839f1dfdfcbf5ad2948d96"
   integrity sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==
@@ -1709,9 +1699,9 @@ camelcase@^5.0.0:
   integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
 
 caniuse-lite@^1.0.30000928:
-  version "1.0.30000928"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000928.tgz#805e828dc72b06498e3683a32e61c7507fd67b88"
-  integrity sha512-aSpMWRXL6ZXNnzm8hgE4QDLibG5pVJ2Ujzsuj3icazlIkxXkPXtL+BWnMx6FBkWmkZgBHGUxPZQvrbRw2ZTxhg==
+  version "1.0.30000929"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000929.tgz#7b391b781a9c3097ecc39ea053301aea8ea16317"
+  integrity sha512-n2w1gPQSsYyorSVYqPMqbSaz1w7o9ZC8VhOEGI9T5MfGDzp7sbopQxG6GaQmYsaq13Xfx/mkxJUWC1Dz3oZfzw==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -2247,7 +2237,7 @@ debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@^1.0.1:
+debuglog@*, debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -2574,9 +2564,9 @@ ejs@^2.6.1:
   integrity sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
 
 electron-to-chromium@^1.3.100:
-  version "1.3.102"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.102.tgz#3ac43a037c8a63bca3dfa189eb3d90f097196787"
-  integrity sha512-2nzZuXw/KBPnI3QX3UOCSRvJiVy7o9+VHRDQ3D/EHCvVc89X6aj/GlNmEgiR2GBIhmSWXIi4W1M5okA5ScSlNg==
+  version "1.3.103"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.103.tgz#a695777efdbc419cad6cbb0e58458251302cd52f"
+  integrity sha512-tObPqGmY9X8MUM8i3MEimYmbnLLf05/QV5gPlkR8MQ3Uj8G8B2govE1U4cQcBYtv3ymck9Y8cIOu4waoiykMZQ==
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -2670,9 +2660,9 @@ es-to-primitive@^1.2.0:
     is-symbol "^1.0.2"
 
 es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.46"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.46.tgz#efd99f67c5a7ec789baa3daa7f79870388f7f572"
-  integrity sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==
+  version "0.10.47"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.47.tgz#d24232e1380daad5449a817be19bde9729024a11"
+  integrity sha512-/1TItLfj+TTfWoeRcDn/0FbGV6SNo4R+On2GGVucPU/j3BWnXE2Co8h8CTo4Tu34gFJtnmwS9xiScKs4EjZhdw==
   dependencies:
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"
@@ -3432,9 +3422,9 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.2.2:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
-  integrity sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.6.tgz#d3a1864a71876a2eb9b244e3bd8f606eb09568c0"
+  integrity sha512-BalK54tfK0pMC0jQFb2oHn1nz7JNQD/2ex5pBnCHgBi2xG7VV0cAOGy2RS2VbCqUXx5/6obMrMcQTJ8yjcGzbg==
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
@@ -4048,7 +4038,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@^0.1.4:
+imurmurhash@*, imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -4817,9 +4807,9 @@ load-json-file@^4.0.0:
     strip-bom "^3.0.0"
 
 loader-runner@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.1.tgz#026f12fe7c3115992896ac02ba022ba92971b979"
-  integrity sha512-By6ZFY7ETWOc9RFaAIb23IjJVcM4dvJC/N57nmdz9RSkMXvAXGI7SyVlAw3v8vjtDRlqThgVDVmTnr9fqMlxkw==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
+  integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
 loader-utils@^0.2.16:
   version "0.2.17"
@@ -4863,6 +4853,11 @@ lockfile@~1.0.3:
   dependencies:
     signal-exit "^3.0.2"
 
+lodash._baseindexof@*:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
+  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
+
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4871,10 +4866,32 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
+lodash._bindcallback@*:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
+  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
+
+lodash._cacheindexof@*:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
+  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
+
+lodash._createcache@*:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
+  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
+  dependencies:
+    lodash._getnative "^3.0.0"
+
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
+
+lodash._getnative@*, lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -4890,6 +4907,11 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
+lodash.restparam@*:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
+  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.union@~4.6.0:
   version "4.6.0"
@@ -5004,9 +5026,9 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 math-random@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.2.tgz#8ab7f026363816c1e00b774d87dee67f61e37ad6"
-  integrity sha512-Bp2Bx2wFaUymE7pWi0bbldiheIXMvyzC3hRkT5YAv2qiqqJO5VB8KafgYgZmGCxkTmloLuAx3Jv2OmJ66990mg==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
+  integrity sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==
 
 md5-hex@^1.2.0:
   version "1.3.0"
@@ -6081,9 +6103,9 @@ pacote@~2.7.38:
     which "^1.2.12"
 
 pako@~1.0.5:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.7.tgz#2473439021b57f1516c82f58be7275ad8ef1bb27"
-  integrity sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ==
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.8.tgz#6844890aab9c635af868ad5fecc62e8acbba3ea4"
+  integrity sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==
 
 parallel-transform@^1.1.0:
   version "1.1.0"
@@ -6731,7 +6753,7 @@ readable-stream@~1.1.10, readable-stream@~1.1.11, readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
@@ -8319,7 +8341,7 @@ v8-compile-cache@^2.0.2:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz#a428b28bb26790734c4fc8bc9fa106fccebf6a6c"
   integrity sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==
 
-validate-npm-package-license@^3.0.1:
+validate-npm-package-license@*, validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==


### PR DESCRIPTION
@xintongxia - by moving your nice quaternion to euler conversion function from 	`Quaternion.toEuler` into `Euler.fromQuaternion` we can significantly lower the bundle size impact of importing `Quaternion` without `Euler` from 32K to 9K, see below.

Do you think it is OK for the app to use `new Euler().fromQuaternion(q)` instead of `q.toEuler()`?

---

Running `yarn metrics` now measures tree shaken size of each class.

Before 

| Version        | Dist | Bundle Size      | Compressed     | Imports   |
| ---            | ---  | ---              | ---            | ---       |
| 2.3.0-beta.1   | es6  | 38KB (39175) KB  | 10KB (10715) KB     | all.js |
| 2.3.0-beta.1   | es6  | 32KB (33494) KB  | 9KB (9221) KB     | euler.js |
| 2.3.0-beta.1   | es6  | 32KB (33462) KB  | 9KB (9242) KB     | quaternion.js |

After 


| Version        | Dist | Bundle Size      | Compressed     | Imports   |
| ---            | ---  | ---              | ---            | ---       |
| 2.3.0-beta.1   | es5  | 79KB (81476) KB  | 18KB (18851) KB     | all |
| 2.3.0-beta.1   | es6  | 32KB (33494) KB  | 9KB (9221) KB     | euler.js |
| 2.3.0-beta.1   | es6  | 9KB (9629) KB  | 3KB (3167) KB     | quaternion.js |
