### PR TITLE
Module RFCs

### DIFF
--- a/dev-docs/RFCs/README.md
+++ b/dev-docs/RFCs/README.md
@@ -1,0 +1,21 @@
+# RFCs and Roadmaps (math.gl)
+
+Implementation of non-trivial new features should typically be started off with the creation of an RFC (Request for Comments). For more details see [RFC Guidelines](../RFC-GUIDELINES.md) .
+
+## Roadmaps
+
+Writeups of directions in major areas of interest
+
+| Roadmap | Description |
+| ------- | ----------- |
+| N/A     | TBD         |
+
+## v3.0 RFCs
+
+
+| RFC                                                             | Author   | Status          | Description                                                                                                                          |
+| --------------------------------------------------------------- | -------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [**Monorepo Module Structure**](./monorepo-rfc.md) | @ibgreen | **Draft**       | Proposes a module structure for math.gl to group similar math functionality into sub-libraries.                                              |
+| [**New Geometry Module**](./geometry-module-rfc.md)             | @ibgreen | **Drafr** | New loaders.gl submodule collecting framework-agnostic geometry utilities |
+| [**New Geospatial Module**](./geometry-module-rfc.md)             | @ibgreen | **Drafr** | New loaders.gl submodule collecting framework-agnostic geospatial utilities |
+| [**New Culling Module**](./geometry-module-rfc.md)             | @ibgreen | **Drafr** | New loaders.gl submodule collecting framework-agnostic culling utilities |

--- a/dev-docs/RFCs/culling-module-rfc.md
+++ b/dev-docs/RFCs/culling-module-rfc.md
@@ -1,0 +1,18 @@
+# Culling Module for math.gl RFC
+
+* **Authors**: Ib Green
+* **Date**: Apr 2019
+* **Status**: Unfinished Draft
+
+## Summary
+
+This RFC proposes adding a new submodule `@math.gl/culling`, adding support for frustum culling math with a selection of bounding boxes.
+
+## Overview
+
+The vis.gl stack has traditionally relied on GPU processing of geometries but will increasingly require more traditional 3D geometry processing.
+
+## Proposal: New Classes
+
+* CPU side mathematical helper classes (`BoundingBoxes` etc)
+* CPU side geometry calculations (`Frustum` Intersection, ...)

--- a/dev-docs/RFCs/geometry-module-rfc.md
+++ b/dev-docs/RFCs/geometry-module-rfc.md
@@ -1,0 +1,45 @@
+# Geometry Module RFC
+
+* **Authors**: Ib Green
+* **Date**: Apr 2019
+* **Status**: Draft
+
+
+## Summary
+
+This RFC proposes increasing the scope of to math.gl, adding support for
+* Typed Array geometry (like luma.gl `Geometry` class, ...)
+
+## Overview
+
+The vis.gl stack has traditionally relied on GPU processing of geometries but will increasingly require more traditional 3D geometry processing.
+
+This includes:
+* Geometry iteration (indices/modes)
+* Normal calculation
+* Indexed geometry expansion
+
+## Proposals: Geometry Classes and Utilities
+
+* Typed Array geometry (like luma.gl `Geometry` class, ...)
+* Typed Array geometry processing (rimitive Iteration, Normal Calculation, Index Expansion, ...)
+* Typed Array geometries (Cubes, Spheres, ...)
+* CPU side mathematical helper classes (BoundingBoxes etc)
+* CPU side geometry calculations (Ray Casting, Frustum Intersection, ...)
+
+### Monorepo setup
+
+As additional functionality areas are added to math.gl, it is important that we keep the core library small and focused. The simplest mechanism to do this
+
+| Directory           | NPM Module            | Scope   |
+| ---                 | ---                   | ---     |
+| `modules/core`      | `math.gl`             | "Classes for gl-matrix". Compact and powerful |
+| `modules/geometry`  | `@math.gl/geometry`   | Support for WebGL typed array geometries |
+| `modules/geometries`| `@math.gl/geometries` | Library of geometric primitives compatible with . Seeded by luma.gl geometric primitives |
+
+
+### Impact luma.gl
+
+By taking over `Geometry` class and subclasses from `@luma.gl/core` we keep that library focused.
+
+For the initial versions luma.gl will import `@math.gl/geometry` and reexport the `Geometry` classes so that the user does not need to change any code.

--- a/dev-docs/RFCs/geospatial-module-rfc.md
+++ b/dev-docs/RFCs/geospatial-module-rfc.md
@@ -1,0 +1,23 @@
+# RFC: Geospatial Module for math.gl
+
+* **Authors**: Ib Green
+* **Date**: May 2019
+* **Status**: Draft
+
+## Summary
+
+This RFC proposes increasing the scope of to math.gl, adding support for:
+* Bounding Geometries
+* Frustum Culling
+
+
+## Overview
+
+The vis.gl stack has traditionally relied on GPU processing of geometries but will increasingly require more traditional 3D geometry processing.
+
+This includes:
+* Bounding Geometries
+* Frustum Culling
+
+
+## Proposals

--- a/dev-docs/RFCs/math-monorepo-rfc.md
+++ b/dev-docs/RFCs/math-monorepo-rfc.md
@@ -1,0 +1,61 @@
+# RFCL math.gl Monorepo
+
+* **Authors**: Ib Green
+* **Date**: May 2019
+* **Status**: Draft
+
+## Summary
+
+This RFC proposes splitting math.gl into a monorepo with multiple submodules.
+
+## Background
+
+With efforts like [3D Tiles](https://github.com/uber-web/loaders.gl/issues/164) we are starting to need a more extensive math library for classical 3D and geospatial math.
+
+As additional functionality areas are added to math.gl, it is important that we keep the core library small and focused.
+
+This RFC proposes increasing the scope of math.gl to include a suite of complementary modules.
+
+## Design Philosophy
+
+### Framework Independence
+
+- Ideally the APIs of the various submodules would not depend on the `math.gl` core library.
+- I.e. apps could use pure JavaScript vectors for arrays and matrices.
+- Note: the submodules can still depend on math.gl core for help with implementation.
+
+Example:
+
+Using with pure javascript `Array`
+```js
+import {Ellipsoid} from '@math.gl/geospatial';
+const cartesian = Ellipsoid.WSG84.cartographicToCartesian([lng, lat, z]);
+```
+
+Using with math.gl `Vector3`:
+```js
+import {Ellipsoid} from '@math.gl/geospatial';
+import {Vector3} from 'math.gl';
+const cartesian = Ellipsoid.WSG84.cartographicToCartesian(new Vector3(lng, lat, z));
+```
+
+### Dependencies and Bundle Size
+
+Concerns:
+* **math.gl bundle size** - As additional functional areas are added to math.gl, it is important that we keep the core library small. The simplest mechanism to do this is to move to a monorepo setup, see detailed proposal below.
+* **math.gl scope** - The library has always claimed a focus on math that supports WebGL applications, adding additional modules is not a sudden change in scope. Also THREE.js math library.
+
+Ideally:
+- the various math.gl libraries do not depend on each other (i.e. they can be cherry-picked by the user to manage dependencies and bundle size).
+- If they depend on each other they do so in a clearly described, layered fashion (no circular dependencies or surprises).
+- The classes inside each library are designed to support three-shaking so that only the classes actually imported and used will be bundled. (i.e. importing one class does not include others just to provide a convenience `toOtherClass()` conversion function).
+
+## Proposal: Monorepo setup
+
+| Directory            | NPM Module            | RFC     | Scope   |
+| ---                  | ---                   | ---     | ---     |
+| `modules/core`       | `math.gl`             | "Classes for gl-matrix". Compact and powerful |
+| `modules/geospatial` | `@math.gl/geospatial` | "Advanced" geospatial math. |
+| `modules/culling`    | `@math.gl/culling`    | Frustum "Culling" and bounding boxes. |
+| `modules/geometry`   | `@math.gl/geometry`   | Support for WebGL typed array geometries |
+| `modules/geometries` | `@math.gl/geometries` | Library of geometric primitives compatible with the geometry system. Seeded by luma.gl geometric primitives |

--- a/dev-docs/ROADMAP.md
+++ b/dev-docs/ROADMAP.md
@@ -1,8 +1,10 @@
-## About Performance
+# Roadmap
+
+## Performance
 
 TBA:
 * Quantify
-* Add bench target?
+* Add bench target
 
 
 ## About Library Size


### PR DESCRIPTION
Just FYI, initial versions of RFCs for new math.gl modules, will iterate on them together with documentation (which is  being built out in [loaders.gl docs](https://github.com/uber-web/loaders.gl/tree/master/docs/api-reference/math) as a temporary location).