### PR TITLE
@math.gl/geospatial: new module, initial commit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,15 @@
 # Introduction
 
-math.gl is a JavaScript class library for 3D math. It provides the traditional 3D classes (vectors, matrices etc).
+math.gl is a JavaScript class library for 3D and geospatial math. It provides a set of "traditional" 3D classes for vectors, matrices etc, as well as a set of optional modules that address different domains.
 
 In spite of the name, math.gl has no hard WebGL dependencies and is usable in any JavaScript applications. That said, math.gl is designed to be optimized for WebGL/3D applications.
 
+## Available Modules
 
-## Features
+- `math.gl` - basic math classes (vectors, matrices etc).
+- `@math.gl/geospatial` - support for geospatial math, primarily WGS84 and Web Mercator.
+
+## Class Library Features
 
 - `math.gl`: Basic math classes (vectors, matrices etc) and utilities (`toRadians` etc).
 - `@math.gl/geospatial`: Support for geospatial math, primarily the WGS84 coordinate system.

--- a/docs/api-reference/geospatial/ellipsoid.md
+++ b/docs/api-reference/geospatial/ellipsoid.md
@@ -1,0 +1,267 @@
+# Ellipsoid
+
+A quadratic surface defined in Cartesian coordinates by the equation `(x / a)^2 + (y / b)^2 + (z / c)^2 = 1`. Primarily used to represent the shape of planetary bodies.
+
+The main use of this class is to convert between the "cartesian" and "cartographic" coordinate systems.
+
+Rather than constructing this object directly, one of the provided constants is used.
+
+## Usage
+
+Determine the Cartesian representation of a Cartographic position on a WGS84 ellipsoid.
+```js
+import {toRadians} from 'math.gl';
+import {Ellipsoid} from '@math.gl/geospatial';
+const cartographicPosition = [toRadians(21), toRadians(78), 5000];
+const cartesianPosition = Ellipsoid.WGS84.cartographicToCartesian(cartographicPosition);
+```
+
+Determine the Cartographic representation of a Cartesian position on a WGS84 ellipsoid.
+```js
+import {Ellipsoid} from '@math.gl/geospatial';
+const cartesianPosition = [17832.12, 83234.52, 952313.73];
+const cartographicPosition = Ellipsoid.WGS84.cartesianToCartographic(cartesianPosition);
+```
+
+Get the transform from local east-north-up at cartographic (0.0, 0.0) to Earth's fixed frame.
+```js
+import {Ellipsoid} from '@math.gl/geospatial';
+const transformMatrix = Ellipsoid.WGS84.eastNorthUpToFixedFrame([0, 0, 0]);
+```
+
+## Static Fields
+
+#### Ellipsoid.WGS84 : Ellipsoid (readonly)
+
+An Ellipsoid instance initialized to the WGS84 standard.
+
+## Members
+
+#### radii : Vector3 (readonly)
+
+Gets the radii of the ellipsoid.
+
+#### radiiSquared : Vector3 (readonly)
+
+Gets the squared radii of the ellipsoid.
+
+#### radiiToTheFourth : Vector3 (readonly)
+
+Gets the radii of the ellipsoid raise to the fourth power.
+
+#### oneOverRadii : Vector3 (readonly)
+
+Gets one over the radii of the ellipsoid.
+
+#### oneOverRadiiSquared : Vector3 (readonly)
+
+Gets one over the squared radii of the ellipsoid.
+
+#### minimumRadius : Number (readonly)
+
+Gets the minimum radius of the ellipsoid.
+
+#### maximumRadius : Number
+
+Gets the maximum radius of the ellipsoid.
+
+## Methods
+
+#### constructor(x : Number, y : Number, z : Number)
+
+- `x`=`0` The radius in the x direction.
+- `y`=`0` The radius in the y direction.
+- `z`=`0` The radius in the z direction.
+
+Throws
+
+- All radii components must be greater than or equal to zero.
+
+#### clone() : Ellipsoid
+
+Duplicates an Ellipsoid instance.
+
+- {Ellipsoid} [result] Optional object onto which to store the result, or undefined if a new
+  instance should be created.
+
+Returns
+- The cloned `Ellipsoid`.
+
+#### equals(right : Ellipsoid) : Boolean
+
+Compares this Ellipsoid against the provided Ellipsoid componentwise.
+
+- `right` The other Ellipsoid. used.
+
+Returns
+- `true` if they are equal, `false` otherwise.
+
+#### toString() : String
+
+Creates a string representing this Ellipsoid in the format used `'[radii.x, radii.y, radii.z]`.
+
+Returns
+
+- A string representing this ellipsoid in the format '(radii.x, radii.y, radii.z)'.
+
+#### cartographicToCartesian(cartographic : Number[3] [, result : Number[3]]) : Vector3 | Number[3]
+
+Converts the provided cartographic to Cartesian representation.
+
+- `cartographic` The cartographic position.
+- `result` Optional object onto which to store the result.
+
+Returns
+
+- The modified `result` parameter or a new `Vector3` instance if none was provided.
+
+#### cartesianToCartographic(cartesian : Number[3] [, result : Number[3]]) : Vector3 | Number[3] | `undefined`
+
+Converts the provided cartesian to cartographic representation. The cartesian is `undefined` at the center of the ellipsoid.
+
+- `cartesian` The Cartesian position to convert to cartographic representation.
+- `result` Optional object onto which to store the result.
+
+Returns
+
+- The modified result parameter, new `Vector3` instance if none was provided, or undefined if the cartesian is at the center of the ellipsoid.
+
+
+#### eastNorthUpToFixedFrame(origin : Number[3], ellpsoid : Ellipsoid, result : Number[16]) : Matrix4 | Number[16]
+
+Computes a 4x4 transformation matrix from a reference frame with an east-north-up axes centered at the provided origin to the provided ellipsoid's fixed reference frame.
+
+The local axes are defined as:
+- The `x` axis points in the local east direction.
+- The `y` axis points in the local north direction.
+- The `z` axis points in the direction of the ellipsoid surface normal which passes through the position.
+
+- `origin` The center point of the local reference frame.
+- `ellipsoid`=`Ellipsoid.WGS84` The ellipsoid whose fixed frame is used in the transformation.
+- `result` Optional object onto which to store the result.
+
+Returns
+
+- The modified `result` parameter or a new `Matrix4` instance if none was provided.
+
+Notes
+
+- Calls `localFrameToFixedFrame` with `east`, `north`, `up` axis.
+
+#### localFrameToFixedFrame(String firstAxis, secondAxis : String, thirdAxis : String | null, origin : Number[3] \[, result : Number[16]]) : Matrix4 | Number[16]
+
+Computes a 4x4 transformation matrix from a reference frame centered at the provided origin to the ellipsoid's fixed reference frame.
+
+- `firstAxis`  name of the first axis of the local reference frame. Must be 'east', 'north', 'up', 'west', 'south' or 'down'.
+- `secondAxis`  name of the second axis of the local reference frame.
+- `thirdAxis`  name of the third axis of the local reference frame. Can be omitted as it is implied by the cross product of the first two axis.
+- `origin` The center point of the local reference frame.
+- `result` Optional object onto which to store the result.
+
+Returns
+
+- A 4x4 transformation matrix from a reference frame, with first axis and second axis compliant with the parameters, in the modified `result` parameter or a new `Matrix4` instance if none was provided.
+
+#### geocentricSurfaceNormal(cartesian : Number[3] [, result : Number[3]]) : Vector3 | Number[3]
+
+Computes the unit vector directed from the center of this ellipsoid toward the provided Cartesian position.
+
+- `cartesian` - The WSG84 cartesian coordinate for which to to determine the geocentric normal.
+- `result` - Optional object onto which to store the result.
+
+Returns
+
+- The modified result parameter or a new `Vector3` instance if none was provided.
+
+#### geodeticSurfaceNormalCartographic(cartographic : Number[3] [, result : Number[3]]) : Vector3 | Number[3]
+
+Computes the normal of the plane tangent to the surface of the ellipsoid at the provided position.
+
+- `cartographic` The cartographic position for which to to determine the geodetic normal.
+- `result` Optional object onto which to store the result.
+
+Returns
+
+The modified result parameter or a new `Vector3` instance if none was provided.
+
+#### geodeticSurfaceNormal(cartesian : Number[3] [, result : Number[3]]) : Vector3 | Number[3]
+
+Computes the normal of the plane tangent to the surface of the ellipsoid at the provided position.
+
+- `cartesian` The Cartesian position for which to to determine the surface normal.
+- `result` Optional object onto which to store the result.
+
+Returns
+
+- The modified `result` parameter or a new `Vector3` instance if none was provided.
+
+#### scaleToGeodeticSurface(cartesian : Number[3] [, result : Number[3]]) : Vector3 | Number[3] | `undefined`
+
+Scales the provided Cartesian position along the geodetic surface normal so that it is on the surface of this ellipsoid. If the position is at the center of the ellipsoid, this function returns `undefined`.
+
+- `cartesian` The Cartesian position to scale.
+- `result` Optional object onto which to store the result.
+
+Returns
+
+- The modified result parameter, a new `Vector3` instance if none was provided, or undefined if the position is at the center.
+
+#### scaleToGeocentricSurface(cartesian : Number[3] [, result : Number[3]]) : Vector3 | Number[3]
+
+Scales the provided Cartesian position along the geocentric surface normal so that it is on the surface of this ellipsoid.
+
+- `cartesian` The Cartesian position to scale.
+- `result` Optional object onto which to store the result.
+
+Returns
+- The modified `result` parameter or a new `Vector3` instance if none was provided.
+
+#### transformPositionToScaledSpace(position : Number[3] [, result : Number[3]]) : Vector3 | Number[3]
+
+Transforms a Cartesian X, Y, Z position to the ellipsoid-scaled space by multiplying its components by the result of `Ellipsoid.oneOverRadii`.
+
+- `position` The position to transform.
+- `result` Optional array into which to copy the result.
+
+Returns
+
+- The position expressed in the scaled space. The returned instance is the one passed as the `result` parameter if it is not undefined, or a new instance of it is.
+
+#### transformPositionFromScaledSpace(position : Number[3] [, result : Number[3]]) : Vector3 | Number[3]
+
+Transforms a Cartesian X, Y, Z position from the ellipsoid-scaled space by multiplying its components by the result of `Ellipsoid.radii`.
+
+- `position` The position to transform.
+- `result` Optional array to which to copy the result.
+
+Returns
+
+- The position expressed in the unscaled space. The returned array is the one passed as the `result` parameter, or a new `Vector3` instance.
+
+#### getSurfaceNormalIntersectionWithZAxis(position, buffer, result) : | undefined
+
+Computes a point which is the intersection of the surface normal with the z-axis.
+
+- `position` the position. must be on the surface of the ellipsoid.
+- `buffer`=`0.0` A buffer to subtract from the ellipsoid size when checking if the point is inside the ellipsoid.
+- `result` Optional array into which to copy the result.
+
+Returns
+
+- The intersection point if it's inside the ellipsoid, `undefined` otherwise.
+
+Throws
+
+- `position` is required.
+- `Ellipsoid` must be an ellipsoid of revolution (`radii.x == radii.y`).
+- Ellipsoid.radii.z must be greater than 0.
+
+Notes:
+
+- In earth case, with common earth datums, there is no need for this buffer since the intersection point is always (relatively) very close to the center.
+- In WGS84 datum, intersection point is at max z = +-42841.31151331382 (0.673% of z-axis).
+- Intersection point could be outside the ellipsoid if the ratio of MajorAxis / AxisOfRotation is bigger than the square root of 2
+
+## Attribution
+
+This class was ported from [Cesium](https://github.com/AnalyticalGraphicsInc/cesium) under the Apache 2 License.

--- a/docs/developer-guide/geospatial/geospatial.md
+++ b/docs/developer-guide/geospatial/geospatial.md
@@ -1,0 +1,49 @@
+# Geospatial Math
+
+The `@math.gl/geospatial` librarys provides support for geospatial math.
+
+It provides classes and utilities to facilitate working with the major geospatial coordinate systems and projections used with computer maps, primarily:
+
+- [WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System) (World Geodetic System) coordinates.
+- [Web Mercator Projection](https://en.wikipedia.org/wiki/Web_Mercator_projection)
+
+
+## Ellipsoid and WGS84
+
+| Class                   | Dewscription |
+| ---                     | --- |
+| `Ellipsoid`             | Implements ellipsoid |
+| `Ellipsoid.WSG84`       | An `Ellipsoid` instance initialized with Earth radii per WGS84. |
+
+## Usage Examples
+
+A major use of this library is to convert between "cartesian" (`x`, `y`, `z`) and "cartographic" (`longitude`, `latitude`, `height`) representations of WSG84 coordinates. The `Ellipsoid` class implements these calculations.
+
+## Usage
+
+Determine the Cartesian representation of a Cartographic position on a WGS84 ellipsoid.
+```js
+import {toRadians} from 'math.gl';
+import {Ellipsoid} from '@math.gl/geospatial';
+const cartographicPosition = [toRadians(21), toRadians(78), 5000];
+const cartesianPosition = Ellipsoid.WGS84.cartographicToCartesian(cartographicPosition);
+```
+
+Determine the Cartographic representation of a Cartesian position on a WGS84 ellipsoid.
+```js
+import {Ellipsoid} from '@math.gl/geospatial';
+const cartesianPosition = [17832.12, 83234.52, 952313.73];
+const cartographicPosition = Ellipsoid.WGS84.cartesianToCartographic(cartesianPosition);
+```
+
+Get the transform from local east-north-up at cartographic (0.0, 0.0) to Earth's fixed frame.
+```js
+import {Ellipsoid} from '@math.gl/geospatial';
+const transformMatrix = Ellipsoid.WGS84.eastNorthUpToFixedFrame([0, 0, 0]);
+```
+
+## Framework Independence
+
+Like all non-core math.gl modules, this module can be used independently of core math.gl classes.
+
+- Any input or result vectors can be supplied as JavaScript `Array` instances of length 3, or objects with `x`, `y`, `z` elements.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -30,6 +30,12 @@
           ]
         },
         {
+          "title": "Geospatial Math",
+          "entries": [
+            {"entry": "docs/developer-guide/geospatial"}
+          ]
+        },
+        {
           "title": "Concepts",
           "entries": [
             {"entry": "docs/developer-guide/concepts/homogenous-coordinates"},
@@ -63,6 +69,12 @@
           "title": "Add-ons",
           "entries": [
             {"entry": "docs/api-reference/addons/polygon"}
+          ]
+        },
+        {
+          "title": "Geospatial",
+          "entries": [
+            {"entry": "docs/api-reference/math/geospatial/ellipsoid"}
           ]
         }
       ]

--- a/modules/core/src/lib/common.js
+++ b/modules/core/src/lib/common.js
@@ -69,7 +69,7 @@ export function isArray(value) {
 
 // If the array has a clone function, calls it, otherwise returns a copy
 export function clone(array) {
-  return array.clone ? array.clone() : new Array(array);
+  return array.clone ? array.clone() : new Array(...array);
 }
 
 // If the argument value is an array, applies the func element wise,

--- a/modules/core/test/lib/common.spec.js
+++ b/modules/core/test/lib/common.spec.js
@@ -53,14 +53,20 @@ test('math.equals', t => {
   t.notOk(equals(1.0, 0.0), 'should return false for different numbers');
   tapeEquals(t, 1.0, 1.0, 'should return true for the same number');
   tapeEquals(t, 1.0 + config.EPSILON / 2, 1.0, 'should return true for numbers that are close');
-  tapeEquals(t, [1.0, 2.0], new Float32Array([1.0, 2.0]),
+  tapeEquals(
+    t,
+    [1.0, 2.0],
+    new Float32Array([1.0, 2.0]),
     'should return true for Array and TypedArray with same values'
   );
   t.notOk(
     equals([1.0, 2.0], new Float32Array([1.0, 3.0])),
     'should return false for Array and TypedArray with different values'
   );
-  tapeEquals(t, [1.0, 2.0], new Vector2([1.0, 2.0]),
+  tapeEquals(
+    t,
+    [1.0, 2.0],
+    new Vector2([1.0, 2.0]),
     'should return true for Array and Vector2 with same values'
   );
   t.end();
@@ -91,33 +97,45 @@ test('math.exactEquals', t => {
 
 test('math#toRadians', t => {
   tapeEquals(t, toRadians(180), Math.PI, 'should return a value of 3.141592654(Math.PI)');
-  tapeEquals(t, toRadians([180, 90]), [Math.PI, Math.PI /2], 'should return a value of 3.141592654(Math.PI)');
+  tapeEquals(
+    t,
+    toRadians([180, 90]),
+    [Math.PI, Math.PI / 2],
+    'should return a value of 3.141592654(Math.PI)'
+  );
   t.end();
 });
 
 test('math#toDegrees', t => {
   tapeEquals(t, toDegrees(Math.PI), 180, 'should return a value of 180');
-  tapeEquals(t, toDegrees([Math.PI, Math.PI /2]), [180, 90], 'should return a value of 180');
+  tapeEquals(t, toDegrees([Math.PI, Math.PI / 2]), [180, 90], 'should return a value of 180');
   t.end();
 });
 
-
 test('math#radians', t => {
   tapeEquals(t, radians(180), Math.PI, 'should return a value of 3.141592654(Math.PI)');
-  tapeEquals(t, radians([180, 90]), [Math.PI, Math.PI /2], 'should return a value of 3.141592654(Math.PI)');
+  tapeEquals(
+    t,
+    radians([180, 90]),
+    [Math.PI, Math.PI / 2],
+    'should return a value of 3.141592654(Math.PI)'
+  );
   t.end();
 });
 
 test('math#degrees', t => {
   tapeEquals(t, degrees(Math.PI), 180, 'should return a value of 180');
-  tapeEquals(t, degrees([Math.PI, Math.PI /2]), [180, 90], 'should return a value of 180');
+  tapeEquals(t, degrees([Math.PI, Math.PI / 2]), [180, 90], 'should return a value of 180');
   t.end();
 });
 
 test('math#lerp', t => {
   tapeEquals(t, lerp(1.0, 2.0, 0.2), 1.2, 'interpolate between numbers');
   tapeEquals(t, lerp([1.0, 0.0], [2.0, -1.0], 0.2), [1.2, -0.2], 'interpolate between arrays');
-  tapeEquals(t, lerp(new Float32Array([1.0, 0.0]), [2.0, -1.0], 0.2), [1.2, -0.2],
+  tapeEquals(
+    t,
+    lerp(new Float32Array([1.0, 0.0]), [2.0, -1.0], 0.2),
+    [1.2, -0.2],
     'interpolate between arrays'
   );
   t.end();

--- a/modules/core/test/lib/common.spec.js
+++ b/modules/core/test/lib/common.spec.js
@@ -18,9 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {isArray, radians, equals, exactEquals, lerp, config, Vector2} from 'math.gl';
-// import {tapeEquals} from './index';
 import test from 'tape-catch';
+import {tapeEquals} from 'test/utils/tape-assertions';
+import {config, isArray, toRadians, toDegrees, equals, exactEquals, lerp, Vector2} from 'math.gl';
+import {radians, degrees} from 'math.gl';
 
 test('Math#types', t => {
   t.equals(typeof isArray, 'function');
@@ -50,18 +51,16 @@ test('Math#construct and isArray check', t => {
 
 test('math.equals', t => {
   t.notOk(equals(1.0, 0.0), 'should return false for different numbers');
-  t.ok(equals(1.0, 1.0), 'should return true for the same number');
-  t.ok(equals(1.0 + config.EPSILON / 2, 1.0), 'should return true for numbers that are close');
-  t.ok(
-    equals([1.0, 2.0], new Float32Array([1.0, 2.0])),
+  tapeEquals(t, 1.0, 1.0, 'should return true for the same number');
+  tapeEquals(t, 1.0 + config.EPSILON / 2, 1.0, 'should return true for numbers that are close');
+  tapeEquals(t, [1.0, 2.0], new Float32Array([1.0, 2.0]),
     'should return true for Array and TypedArray with same values'
   );
   t.notOk(
     equals([1.0, 2.0], new Float32Array([1.0, 3.0])),
     'should return false for Array and TypedArray with different values'
   );
-  t.ok(
-    equals([1.0, 2.0], new Vector2([1.0, 2.0])),
+  tapeEquals(t, [1.0, 2.0], new Vector2([1.0, 2.0]),
     'should return true for Array and Vector2 with same values'
   );
   t.end();
@@ -90,16 +89,35 @@ test('math.exactEquals', t => {
   t.end();
 });
 
+test('math#toRadians', t => {
+  tapeEquals(t, toRadians(180), Math.PI, 'should return a value of 3.141592654(Math.PI)');
+  tapeEquals(t, toRadians([180, 90]), [Math.PI, Math.PI /2], 'should return a value of 3.141592654(Math.PI)');
+  t.end();
+});
+
+test('math#toDegrees', t => {
+  tapeEquals(t, toDegrees(Math.PI), 180, 'should return a value of 180');
+  tapeEquals(t, toDegrees([Math.PI, Math.PI /2]), [180, 90], 'should return a value of 180');
+  t.end();
+});
+
+
 test('math#radians', t => {
-  t.ok(equals(radians(180), Math.PI), 'should return a value of 3.141592654(Math.PI)');
+  tapeEquals(t, radians(180), Math.PI, 'should return a value of 3.141592654(Math.PI)');
+  tapeEquals(t, radians([180, 90]), [Math.PI, Math.PI /2], 'should return a value of 3.141592654(Math.PI)');
+  t.end();
+});
+
+test('math#degrees', t => {
+  tapeEquals(t, degrees(Math.PI), 180, 'should return a value of 180');
+  tapeEquals(t, degrees([Math.PI, Math.PI /2]), [180, 90], 'should return a value of 180');
   t.end();
 });
 
 test('math#lerp', t => {
-  t.ok(equals(lerp(1.0, 2.0, 0.2), 1.2), 'interpolate between numbers');
-  t.ok(equals(lerp([1.0, 0.0], [2.0, -1.0], 0.2), [1.2, -0.2]), 'interpolate between arrays');
-  t.ok(
-    equals(lerp(new Float32Array([1.0, 0.0]), [2.0, -1.0], 0.2), [1.2, -0.2]),
+  tapeEquals(t, lerp(1.0, 2.0, 0.2), 1.2, 'interpolate between numbers');
+  tapeEquals(t, lerp([1.0, 0.0], [2.0, -1.0], 0.2), [1.2, -0.2], 'interpolate between arrays');
+  tapeEquals(t, lerp(new Float32Array([1.0, 0.0]), [2.0, -1.0], 0.2), [1.2, -0.2],
     'interpolate between arrays'
   );
   t.end();

--- a/modules/core/test/threejs-tests/index.js
+++ b/modules/core/test/threejs-tests/index.js
@@ -6,4 +6,4 @@ import './vector4-three.spec';
 // import './matrix4-three.spec';
 
 // import './euler-three.spec';
-// import './quaternion-three.spec';
+import './quaternion-three.spec';

--- a/modules/core/test/threejs-tests/index.js
+++ b/modules/core/test/threejs-tests/index.js
@@ -6,4 +6,4 @@ import './vector4-three.spec';
 // import './matrix4-three.spec';
 
 // import './euler-three.spec';
-import './quaternion-three.spec';
+// import './quaternion-three.spec';

--- a/modules/geospatial/README.md
+++ b/modules/geospatial/README.md
@@ -1,0 +1,7 @@
+# @math.gl/geospatial
+
+[math.gl](https://math.gl/docs) is a suite of math modules for 3D and geospatial applications.
+
+This module contains geospatial math, for dealing with the WGS84 (World Geodetic System) coordinate system etc.
+
+For documentation please visit the [website](https://math.gl).

--- a/modules/geospatial/package.json
+++ b/modules/geospatial/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@math.gl/geospatial",
+  "description": "Geospatial classes",
+  "license": "MIT",
+  "version": "2.3.0",
+  "keywords": [
+    "webgl",
+    "javascript",
+    "math",
+    "geospatial",
+    "WGS84",
+    "ellipsoid",
+    "cartographic",
+    "cartesian",
+    "projection",
+    "web mercator",
+    "geographic"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uber-web/math.gl.git"
+  },
+  "main": "dist/es5/index.js",
+  "module": "dist/esm/index.js",
+  "esnext": "dist/es6/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@babel/runtime": "^7.0.0",
+    "gl-matrix": "^3.0.0",
+    "math.gl": "^2.3.0"
+  }
+}

--- a/modules/geospatial/src/constants.js
+++ b/modules/geospatial/src/constants.js
@@ -1,0 +1,22 @@
+export const WGS84_RADIUS_X = 6378137.0;
+export const WGS84_RADIUS_Y = 6378137.0;
+export const WGS84_RADIUS_Z = 6356752.3142451793;
+
+// Pre-calculated ellipsoid defaults to avoid utils depending on `ellipsoid.js`
+
+export const WGS84_CONSTANTS = {
+  radii: [WGS84_RADIUS_X, WGS84_RADIUS_Y, WGS84_RADIUS_Z],
+  radiiSquared: [
+    WGS84_RADIUS_X * WGS84_RADIUS_X,
+    WGS84_RADIUS_Y * WGS84_RADIUS_Y,
+    WGS84_RADIUS_Z * WGS84_RADIUS_Z
+  ],
+  oneOverRadii: [1.0 / WGS84_RADIUS_X, 1.0 / WGS84_RADIUS_Y, 1.0 / WGS84_RADIUS_Z],
+  oneOverRadiiSquared: [
+    (1.0 / WGS84_RADIUS_X) * WGS84_RADIUS_X,
+    (1.0 / WGS84_RADIUS_Y) * WGS84_RADIUS_Y,
+    (1.0 / WGS84_RADIUS_Z) * WGS84_RADIUS_Z
+  ],
+  maximumRadius: Math.max(WGS84_RADIUS_X, WGS84_RADIUS_Y, WGS84_RADIUS_Z),
+  centerToleranceSquared: 1e-1 // EPSILON1;
+};

--- a/modules/geospatial/src/ellipsoid/ellipsoid.js
+++ b/modules/geospatial/src/ellipsoid/ellipsoid.js
@@ -1,0 +1,269 @@
+/* eslint-disable */
+import {Vector3, Matrix4, toRadians, toDegrees, assert, _MathUtils} from 'math.gl';
+import * as vec3 from 'gl-matrix/vec3';
+
+import {WGS84_RADIUS_X, WGS84_RADIUS_Y, WGS84_RADIUS_Z} from '../constants';
+import {fromCartographicToRadians, toCartographicFromRadians} from '../type-utils';
+
+import scaleToGeodeticSurface from './helpers/scale-to-geodetic-surface';
+import localFrameToFixedFrame from './helpers/ellipsoid-transform';
+
+const scratchVector = new Vector3();
+const scratchNormal = new Vector3();
+const scratchK = new Vector3();
+const scratchPosition = new Vector3();
+const scratchHeight = new Vector3();
+
+let wgs84;
+
+// A quadratic surface defined in Cartesian coordinates by the equation
+// <code>(x / a)^2 + (y / b)^2 + (z / c)^2 = 1</code>.  Primarily used
+// to represent the shape of planetary bodies.
+export default class Ellipsoid {
+  // An Ellipsoid instance initialized to the WGS84 standard.
+  static get WGS84() {
+    wgs84 = wgs84 || new Ellipsoid(WGS84_RADIUS_X, WGS84_RADIUS_Y, WGS84_RADIUS_Z);
+    return wgs84;
+  }
+
+  // Computes an Ellipsoid from a Cartesian specifying the radii in x, y, and z directions.
+  static fromVector3([x, y, z]) {
+    return new Ellipsoid(x, y, z);
+  }
+
+  constructor(x = 0.0, y = 0.0, z = 0.0) {
+    assert(x >= 0.0);
+    assert(y >= 0.0);
+    assert(z >= 0.0);
+
+    this._radii = new Vector3(x, y, z);
+
+    this._radiiSquared = new Vector3(x * x, y * y, z * z);
+
+    this._radiiToTheFourth = new Vector3(x * x * x * x, y * y * y * y, z * z * z * z);
+
+    this._oneOverRadii = new Vector3(
+      x === 0.0 ? 0.0 : 1.0 / x,
+      y === 0.0 ? 0.0 : 1.0 / y,
+      z === 0.0 ? 0.0 : 1.0 / z
+    );
+
+    this._oneOverRadiiSquared = new Vector3(
+      x === 0.0 ? 0.0 : 1.0 / (x * x),
+      y === 0.0 ? 0.0 : 1.0 / (y * y),
+      z === 0.0 ? 0.0 : 1.0 / (z * z)
+    );
+
+    this._minimumRadius = Math.min(x, y, z);
+
+    this._maximumRadius = Math.max(x, y, z);
+
+    this._centerToleranceSquared = _MathUtils.EPSILON1;
+
+    if (this._radiiSquared.z !== 0) {
+      this._squaredXOverSquaredZ = this._radiiSquared.x / this._radiiSquared.z;
+    }
+
+    Object.freeze(this);
+  }
+
+  // Gets the radii of the ellipsoid.
+  get radii() {
+    return this._radii;
+  }
+
+  // Gets the squared radii of the ellipsoid.
+  get radiiSquared() {
+    return this._radiiSquared;
+  }
+
+  // Gets the radii of the ellipsoid raise to the fourth power.
+  get radiiToTheFourth() {
+    return this._radiiToTheFourth;
+  }
+
+  // Gets one over the radii of the ellipsoid.
+  get oneOverRadii() {
+    return this._oneOverRadii;
+  }
+
+  // Gets one over the squared radii of the ellipsoid.
+  get oneOverRadiiSquared() {
+    return this._oneOverRadiiSquared;
+  }
+
+  get centerToleranceSquared() {
+    return this._centerToleranceSquared;
+  }
+
+  // Gets the minimum radius of the ellipsoid.
+  get minimumRadius() {
+    return this._minimumRadius;
+  }
+
+  // Gets the maximum radius of the ellipsoid.
+  get maximumRadius() {
+    return this._maximumRadius;
+  }
+
+  // Duplicates an Ellipsoid instance.
+  clone(ellipsoid) {
+    const radii = ellipsoid._radii;
+    return new Ellipsoid(radii.x, radii.y, radii.z);
+  }
+
+  // Compares this Ellipsoid against the provided Ellipsoid componentwise and returns
+  equals(right) {
+    return this === right || Boolean(right && this._radii.equals(right._radii));
+  }
+
+  // Creates a string representing this Ellipsoid in the format '(radii.x, radii.y, radii.z)'.
+  toString() {
+    return this._radii.toString();
+  }
+
+  // Converts the provided cartographic to Cartesian representation.
+  cartographicToCartesian(cartographic, result = new Vector3()) {
+    const normal = scratchNormal;
+    const k = scratchK;
+
+    const [, , height] = cartographic;
+    this.geodeticSurfaceNormalCartographic(cartographic, normal);
+    k.copy(this._radiiSquared).scale(normal);
+
+    const gamma = Math.sqrt(normal.dot(k));
+    k.scale(1 / gamma);
+
+    normal.scale(height);
+
+    k.add(normal);
+
+    return k.to(result);
+  }
+
+  // Converts the provided cartesian to cartographic (lng/lat/z) representation.
+  // The cartesian is undefined at the center of the ellipsoid.
+  cartesianToCartographic(cartesian, result = new Vector3()) {
+    const point = this.scaleToGeodeticSurface(cartesian, scratchPosition);
+
+    if (!point) {
+      return undefined;
+    }
+
+    const normal = this.geodeticSurfaceNormal(point, scratchNormal);
+
+    const h = scratchHeight;
+    h.copy(cartesian).subtract(point);
+
+    const longitude = Math.atan2(normal.y, normal.x);
+    const latitude = Math.asin(normal.z);
+    const height = Math.sign(vec3.dot(h, cartesian)) * vec3.length(h);
+
+    return toCartographicFromRadians([longitude, latitude, height], result);
+  }
+
+  // Computes a 4x4 transformation matrix from a reference frame with an east-north-up axes
+  // centered at the provided origin to the provided ellipsoid's fixed reference frame.
+  eastNorthUpToFixedFrame(origin, result = new Matrix4()) {
+    return localFrameToFixedFrame(this, 'east', 'north', 'up', origin, result);
+  }
+
+  // Computes a 4x4 transformation matrix from a reference frame centered at
+  // the provided origin to the ellipsoid's fixed reference frame.
+  localFrameToFixedFrame(firstAxis, secondAxis, thirdAxis, origin, result = new Matrix4()) {
+    return localFrameToFixedFrame(this, firstAxis, secondAxis, thirdAxis, origin, result);
+  }
+
+  // Computes the unit vector directed from the center of this ellipsoid toward
+  // the provided Cartesian position.
+  geocentricSurfaceNormal(cartesian) {
+    return scratchVector.from(cartesian).normalize();
+  }
+
+  // Computes the normal of the plane tangent to the surface of the ellipsoid at provided position.
+  geodeticSurfaceNormalCartographic(cartographic, result = new Vector3()) {
+    const cartographicVectorRadians = fromCartographicToRadians(cartographic);
+
+    const longitude = cartographicVectorRadians[0];
+    const latitude = cartographicVectorRadians[1];
+
+    const cosLatitude = Math.cos(latitude);
+
+    scratchVector
+      .set(cosLatitude * Math.cos(longitude), cosLatitude * Math.sin(longitude), Math.sin(latitude))
+      .normalize();
+
+    return scratchVector.to(result);
+  }
+
+  // Computes the normal of the plane tangent to the surface of the ellipsoid at the provided position.
+  geodeticSurfaceNormal(cartesian, result = new Vector3()) {
+    return scratchVector
+      .from(cartesian)
+      .scale(this._oneOverRadiiSquared)
+      .normalize()
+      .to(result);
+  }
+
+  // Scales the provided Cartesian position along the geodetic surface normal
+  // so that it is on the surface of this ellipsoid.  If the position is
+  // at the center of the ellipsoid, this function returns undefined.
+  scaleToGeodeticSurface(cartesian, result) {
+    return scaleToGeodeticSurface(cartesian, this, result);
+  }
+
+  // Scales the provided Cartesian position along the geocentric surface normal
+  // so that it is on the surface of this ellipsoid.
+  scaleToGeocentricSurface(cartesian, result = new Vector3()) {
+    scratchPosition.from(cartesian);
+
+    const positionX = scratchPosition.x;
+    const positionY = scratchPosition.y;
+    const positionZ = scratchPosition.z;
+    const oneOverRadiiSquared = this._oneOverRadiiSquared;
+
+    const beta =
+      1.0 /
+      Math.sqrt(
+        positionX * positionX * oneOverRadiiSquared.x +
+          positionY * positionY * oneOverRadiiSquared.y +
+          positionZ * positionZ * oneOverRadiiSquared.z
+      );
+
+    return scratchPosition.multiplyScalar(beta).to(result);
+  }
+
+  // Transforms a Cartesian X, Y, Z position to the ellipsoid-scaled space by multiplying
+  // its components by the result of `Ellipsoid#oneOverRadii`
+  transformPositionToScaledSpace(position, result = new Vector3()) {
+    return scratchPosition
+      .from(position)
+      .scale(this._oneOverRadii)
+      .to(result);
+  }
+
+  // Transforms a Cartesian X, Y, Z position from the ellipsoid-scaled space by multiplying
+  // its components by the result of `Ellipsoid#radii`.
+  transformPositionFromScaledSpace(position, result = new Vector3()) {
+    return scratchPosition
+      .from(position)
+      .scale(this._radii)
+      .to(result);
+  }
+
+  // Computes a point which is the intersection of the surface normal with the z-axis.
+  getSurfaceNormalIntersectionWithZAxis(position, buffer = 0.0, result = new Vector3()) {
+    // Ellipsoid must be an ellipsoid of revolution (radii.x == radii.y)
+    assert(equalsEpsilon(this._radii.x, this._radii.y, _MathUtils.EPSILON15));
+    assert(this._radii.z > 0);
+
+    scratchPosition.from(position);
+    const z = scratchPosition.z * (1 - this._squaredXOverSquaredZ);
+
+    if (Math.abs(z) >= this._radii.z - buffer) {
+      return undefined;
+    }
+
+    scratchPosition.set(0.0, 0.0, z).to(result);
+  }
+}

--- a/modules/geospatial/src/ellipsoid/helpers/ellipsoid-transform.js
+++ b/modules/geospatial/src/ellipsoid/helpers/ellipsoid-transform.js
@@ -1,0 +1,147 @@
+import {Vector3, assert, equals as equalsEpsilon} from 'math.gl';
+
+const EPSILON14 = 1e-14;
+// Contains functions for transforming positions to reference frames.
+
+// Caclulate third axis from given two axii
+const VECTOR_PRODUCT_LOCAL_FRAME = {
+  up: {
+    south: 'east',
+    north: 'west',
+    west: 'south',
+    east: 'north'
+  },
+  down: {
+    south: 'west',
+    north: 'east',
+    west: 'north',
+    east: 'south'
+  },
+  south: {
+    up: 'west',
+    down: 'east',
+    west: 'down',
+    east: 'up'
+  },
+  north: {
+    up: 'east',
+    down: 'west',
+    west: 'up',
+    east: 'down'
+  },
+  west: {
+    up: 'north',
+    down: 'south',
+    north: 'down',
+    south: 'up'
+  },
+  east: {
+    up: 'south',
+    down: 'north',
+    north: 'up',
+    south: 'down'
+  }
+};
+
+const degeneratePositionLocalFrame = {
+  north: [-1, 0, 0],
+  east: [0, 1, 0],
+  up: [0, 0, 1],
+  south: [1, 0, 0],
+  west: [0, -1, 0],
+  down: [0, 0, -1]
+};
+
+const scratchAxisVectors = {
+  east: new Vector3(),
+  north: new Vector3(),
+  up: new Vector3(),
+  west: new Vector3(),
+  south: new Vector3(),
+  down: new Vector3()
+};
+
+const scratchVector1 = new Vector3();
+const scratchVector2 = new Vector3();
+const scratchVector3 = new Vector3();
+
+// Computes a 4x4 transformation matrix from a reference frame
+// centered at the provided origin to the provided ellipsoid's fixed reference frame.
+// eslint-disable-next-line max-statements, max-params, complexity
+export default function localFrameToFixedFrame(
+  ellipsoid,
+  firstAxis,
+  secondAxis,
+  thirdAxis,
+  origin,
+  result
+) {
+  const thirdAxisInferred =
+    VECTOR_PRODUCT_LOCAL_FRAME[firstAxis] && VECTOR_PRODUCT_LOCAL_FRAME[firstAxis][secondAxis];
+  // firstAxis and secondAxis must be east, north, up, west, south or down.');
+  assert(thirdAxisInferred && (!thirdAxis || thirdAxis === thirdAxisInferred));
+
+  let firstAxisVector;
+  let secondAxisVector;
+  let thirdAxisVector;
+
+  // If x and y are zero, assume origin is at a pole, which is a special case.
+  const atPole = equalsEpsilon(origin.x, 0.0, EPSILON14) && equalsEpsilon(origin.y, 0.0, EPSILON14);
+
+  if (atPole) {
+    // Look up axis value and adjust
+    const sign = Math.sign(origin.z);
+
+    firstAxisVector = scratchVector1.fromArray(degeneratePositionLocalFrame[firstAxis]);
+    if (firstAxis !== 'east' && firstAxis !== 'west') {
+      firstAxisVector.scale(sign);
+    }
+
+    secondAxisVector = scratchVector2.fromArray(degeneratePositionLocalFrame[secondAxis]);
+    if (secondAxis !== 'east' && secondAxis !== 'west') {
+      secondAxisVector.scale(sign);
+    }
+
+    thirdAxisVector = scratchVector3.fromArray(degeneratePositionLocalFrame[thirdAxis]);
+    if (thirdAxis !== 'east' && thirdAxis !== 'west') {
+      thirdAxisVector.scale(sign);
+    }
+  } else {
+    // Calculate all axis
+    const {up, east, north} = scratchAxisVectors;
+
+    east.set(-origin.y, origin.x, 0.0).normalize();
+    ellipsoid.geodeticSurfaceNormal(origin, up);
+    north.copy(up).cross(east);
+
+    const {down, west, south} = scratchAxisVectors;
+
+    down.copy(up).scale(-1);
+    west.copy(east).scale(-1);
+    south.copy(north).scale(-1);
+
+    // Pick three axis based on desired orientation
+    firstAxisVector = scratchAxisVectors[firstAxis];
+    secondAxisVector = scratchAxisVectors[secondAxis];
+    thirdAxisVector = scratchAxisVectors[thirdAxis];
+  }
+
+  // TODO - assuming the result is column-major
+  result[0] = firstAxisVector.x;
+  result[1] = firstAxisVector.y;
+  result[2] = firstAxisVector.z;
+  result[3] = 0.0;
+  result[4] = secondAxisVector.x;
+  result[5] = secondAxisVector.y;
+  result[6] = secondAxisVector.z;
+  result[7] = 0.0;
+  result[8] = thirdAxisVector.x;
+  result[9] = thirdAxisVector.y;
+  result[10] = thirdAxisVector.z;
+  result[11] = 0.0;
+  result[12] = origin.x;
+  result[13] = origin.y;
+  result[14] = origin.z;
+  result[15] = 1.0;
+  return result;
+}

--- a/modules/geospatial/src/ellipsoid/helpers/scale-to-geodetic-surface.js
+++ b/modules/geospatial/src/ellipsoid/helpers/scale-to-geodetic-surface.js
@@ -1,0 +1,99 @@
+/* eslint-disable */
+import {Vector3, assert, _MathUtils} from 'math.gl';
+import * as vec3 from 'gl-matrix/vec3';
+
+const scratchVector = new Vector3();
+const scaleToGeodeticSurfaceIntersection = new Vector3();
+const scaleToGeodeticSurfaceGradient = new Vector3();
+
+// Scales the provided Cartesian position along the geodetic surface normal
+// so that it is on the surface of this ellipsoid.  If the position is
+// at the center of the ellipsoid, this function returns undefined.
+export default function scaleToGeodeticSurface(cartesian, ellipsoid, result = new Vector3()) {
+  const {oneOverRadii, oneOverRadiiSquared, centerToleranceSquared} = ellipsoid;
+
+  scratchVector.from(cartesian);
+
+  const positionX = cartesian.x;
+  const positionY = cartesian.y;
+  const positionZ = cartesian.z;
+
+  const oneOverRadiiX = oneOverRadii.x;
+  const oneOverRadiiY = oneOverRadii.y;
+  const oneOverRadiiZ = oneOverRadii.z;
+
+  const x2 = positionX * positionX * oneOverRadiiX * oneOverRadiiX;
+  const y2 = positionY * positionY * oneOverRadiiY * oneOverRadiiY;
+  const z2 = positionZ * positionZ * oneOverRadiiZ * oneOverRadiiZ;
+
+  // Compute the squared ellipsoid norm.
+  const squaredNorm = x2 + y2 + z2;
+  const ratio = Math.sqrt(1.0 / squaredNorm);
+
+  // When very close to center or at center
+  if (!Number.isFinite(ratio)) {
+    return undefined;
+  }
+
+  // As an initial approximation, assume that the radial intersection is the projection point.
+  const intersection = scaleToGeodeticSurfaceIntersection;
+  intersection.copy(cartesian).scale(ratio);
+
+  // If the position is near the center, the iteration will not converge.
+  if (squaredNorm < centerToleranceSquared) {
+    return intersection.to(result);
+  }
+
+  const oneOverRadiiSquaredX = oneOverRadiiSquared.x;
+  const oneOverRadiiSquaredY = oneOverRadiiSquared.y;
+  const oneOverRadiiSquaredZ = oneOverRadiiSquared.z;
+
+  // Use the gradient at the intersection point in place of the true unit normal.
+  // The difference in magnitude will be absorbed in the multiplier.
+  const gradient = scaleToGeodeticSurfaceGradient;
+  gradient.set(
+    intersection.x * oneOverRadiiSquaredX * 2.0,
+    intersection.y * oneOverRadiiSquaredY * 2.0,
+    intersection.z * oneOverRadiiSquaredZ * 2.0
+  );
+
+  // Compute the initial guess at the normal vector multiplier, lambda.
+  let lambda = ((1.0 - ratio) * cartesian.len()) / (0.5 * gradient.len());
+  let correction = 0.0;
+
+  let xMultiplier;
+  let yMultiplier;
+  let zMultiplier;
+  let func;
+
+  do {
+    lambda -= correction;
+
+    xMultiplier = 1.0 / (1.0 + lambda * oneOverRadiiSquaredX);
+    yMultiplier = 1.0 / (1.0 + lambda * oneOverRadiiSquaredY);
+    zMultiplier = 1.0 / (1.0 + lambda * oneOverRadiiSquaredZ);
+
+    const xMultiplier2 = xMultiplier * xMultiplier;
+    const yMultiplier2 = yMultiplier * yMultiplier;
+    const zMultiplier2 = zMultiplier * zMultiplier;
+
+    const xMultiplier3 = xMultiplier2 * xMultiplier;
+    const yMultiplier3 = yMultiplier2 * yMultiplier;
+    const zMultiplier3 = zMultiplier2 * zMultiplier;
+
+    func = x2 * xMultiplier2 + y2 * yMultiplier2 + z2 * zMultiplier2 - 1.0;
+
+    // "denominator" here refers to the use of this expression in the velocity and acceleration
+    // computations in the sections to follow.
+    const denominator =
+      x2 * xMultiplier3 * oneOverRadiiSquaredX +
+      y2 * yMultiplier3 * oneOverRadiiSquaredY +
+      z2 * zMultiplier3 * oneOverRadiiSquaredZ;
+
+    const derivative = -2.0 * denominator;
+
+    correction = func / derivative;
+  } while (Math.abs(func) > _MathUtils.EPSILON12);
+
+  return scratchVector.scale([xMultiplier, yMultiplier, zMultiplier]).to(result);
+}

--- a/modules/geospatial/src/index.js
+++ b/modules/geospatial/src/index.js
@@ -1,0 +1,1 @@
+export {default as Ellipsoid} from './ellipsoid/ellipsoid';

--- a/modules/geospatial/src/type-utils.js
+++ b/modules/geospatial/src/type-utils.js
@@ -1,0 +1,55 @@
+import {Vector3, isArray, toRadians, toDegrees, config} from 'math.gl';
+
+const noop = x => x;
+
+const scratchVector = new Vector3();
+
+export function fromCartographic(cartographic, vector, map = noop) {
+  if (isArray(cartographic)) {
+    vector[0] = map(cartographic[0]);
+    vector[1] = map(cartographic[1]);
+    vector[2] = cartographic[2];
+  } else if ('longitude' in cartographic) {
+    vector[0] = map(cartographic.longitude);
+    vector[1] = map(cartographic.latitude);
+    vector[2] = cartographic.height;
+  } else {
+    vector[0] = map(cartographic.longitude);
+    vector[1] = map(cartographic.latitude);
+    vector[2] = cartographic.height;
+  }
+  return vector;
+}
+
+export function fromCartographicToRadians(cartographic, vector = scratchVector) {
+  return fromCartographic(cartographic, vector, config.cartographicRadians ? noop : toRadians);
+}
+
+export function fromCartographicToDegrees(cartographic, vector = scratchVector) {
+  return fromCartographic(cartographic, vector, config.cartographicRadians ? toDegrees : noop);
+}
+
+export function toCartographic(vector, cartographic, map = noop) {
+  if (isArray(cartographic)) {
+    cartographic[0] = map(vector[0]);
+    cartographic[1] = map(vector[1]);
+    cartographic[2] = vector[2];
+  } else if ('longitude' in cartographic) {
+    cartographic.longitude = map(vector[0]);
+    cartographic.latitude = map(vector[1]);
+    cartographic.height = vector[2];
+  } else {
+    cartographic.x = map(vector[0]);
+    cartographic.y = map(vector[1]);
+    cartographic.z = vector[2];
+  }
+  return cartographic;
+}
+
+export function toCartographicFromRadians(vector, cartographic) {
+  return toCartographic(vector, cartographic, config.cartographicRadians ? noop : toDegrees);
+}
+
+export function toCartographicFromDegrees(vector, cartographic) {
+  return toCartographic(vector, cartographic, config.cartographicRadians ? toRadians : noop);
+}

--- a/modules/geospatial/src/type-utils.js
+++ b/modules/geospatial/src/type-utils.js
@@ -14,9 +14,9 @@ export function fromCartographic(cartographic, vector, map = noop) {
     vector[1] = map(cartographic.latitude);
     vector[2] = cartographic.height;
   } else {
-    vector[0] = map(cartographic.longitude);
-    vector[1] = map(cartographic.latitude);
-    vector[2] = cartographic.height;
+    vector[0] = map(cartographic.x);
+    vector[1] = map(cartographic.y);
+    vector[2] = cartographic.z;
   }
   return vector;
 }

--- a/modules/geospatial/test/bench.js
+++ b/modules/geospatial/test/bench.js
@@ -1,0 +1,50 @@
+import {Vector3} from 'math.gl';
+import {
+  fromCartographic,
+  fromCartographicToRadians,
+  toCartographicFromRadians
+} from '../src/type-utils';
+
+import ellipsoidBench from '@math.gl/geospatial/test/ellipsoid/ellipsoid.bench';
+
+class ObjectVector {
+  constructor(x = 0, y = 0, z = 0) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+}
+
+const array = [0, 0, 0];
+const float32Array = new Float32Array([0, 0, 0]);
+const objectVector = new ObjectVector();
+const vector = new Vector3();
+const vector3 = new Vector3();
+
+export default function geospatialBench(suite, addReferenceBenchmarks) {
+  suite
+    .group('Cartographic Type Conversion Cost')
+    .add('fromCartographic#Vector3', () => fromCartographic(vector3, vector))
+    .add('fromCartographicToRadians#Vector3', () => fromCartographicToRadians(vector3, vector))
+    .add('fromCartographicToRadians#Object', () => fromCartographicToRadians(vector3, objectVector))
+    .add('toCartographicFromRadians#Vector3', () => toCartographicFromRadians(vector3, vector))
+    .add('toCartographicFromRadians#Object', () =>
+      toCartographicFromRadians(vector3, objectVector)
+    );
+
+  if (addReferenceBenchmarks) {
+    suite
+      .add('fromCartographicToRadians#Array', () => fromCartographicToRadians(vector3, array))
+      .add('fromCartographicToRadians#Float32Array', () =>
+        fromCartographicToRadians(vector3, float32Array)
+      )
+      .add('toCartographicFromRadians#Array', () => toCartographicFromRadians(vector3, array))
+      .add('toCartographicFromRadians#Float32Array', () =>
+        toCartographicFromRadians(vector3, float32Array)
+      );
+  }
+
+  ellipsoidBench(suite);
+
+  return suite;
+}

--- a/modules/geospatial/test/ellipsoid/ellipsoid-transform.spec.js
+++ b/modules/geospatial/test/ellipsoid/ellipsoid-transform.spec.js
@@ -1,0 +1,390 @@
+import test from 'tape-catch';
+import {Vector3, Vector4, Matrix4} from 'math.gl';
+import {Ellipsoid} from '@math.gl/geospatial';
+
+const negativeX = new Vector4(-1, 0, 0, 0);
+const negativeY = new Vector4(0, -1, 0, 0);
+const negativeZ = new Vector4(0, 0, -1, 0);
+
+Vector4.UNIT_X = new Vector4(1, 0, 0, 0);
+Vector4.UNIT_Y = new Vector4(0, 1, 0, 0);
+Vector4.UNIT_Z = new Vector4(0, 0, 1, 0);
+
+const UNIT_SPHERE = new Ellipsoid(1, 1, 1);
+
+test('Ellipsoid#transforms#eastNorthUpToFixedFrame works without a result parameter', t => {
+  const origin = new Vector3(1.0, 0.0, 0.0);
+  const expectedTranslation = new Vector4(origin.x, origin.y, origin.z, 1.0);
+
+  const returnedResult = UNIT_SPHERE.eastNorthUpToFixedFrame(origin);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(1), Vector4.UNIT_Z); // north
+  t.deepEquals(returnedResult.getColumn(2), Vector4.UNIT_X); // up
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#eastNorthUpToFixedFrame works with a result parameter', t => {
+  const origin = new Vector3(1.0, 0.0, 0.0);
+  const expectedTranslation = new Vector4(origin.x, origin.y, origin.z, 1.0);
+  const result = new Matrix4(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+
+  const returnedResult = UNIT_SPHERE.eastNorthUpToFixedFrame(origin, result);
+  t.equals(result, returnedResult);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(1), Vector4.UNIT_Z); // north
+  t.deepEquals(returnedResult.getColumn(2), Vector4.UNIT_X); // up
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#eastNorthUpToFixedFrame works at the north pole', t => {
+  const northPole = new Vector3(0.0, 0.0, 1.0);
+  const expectedTranslation = new Vector4(northPole.x, northPole.y, northPole.z, 1.0);
+
+  const result = new Matrix4();
+  const returnedResult = UNIT_SPHERE.eastNorthUpToFixedFrame(northPole, result);
+  t.equals(returnedResult, result);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(1), negativeX); // north
+  t.deepEquals(returnedResult.getColumn(2), Vector4.UNIT_Z); // up
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#eastNorthUpToFixedFrame works at the south pole', t => {
+  const southPole = new Vector3(0.0, 0.0, -1.0);
+  const expectedTranslation = new Vector4(southPole.x, southPole.y, southPole.z, 1.0);
+
+  const returnedResult = UNIT_SPHERE.eastNorthUpToFixedFrame(southPole);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(1), Vector4.UNIT_X); // north
+  t.deepEquals(returnedResult.getColumn(2), negativeZ); // up
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northEastDownToFixedFrame works without a result parameter', t => {
+  const origin = new Vector3(1.0, 0.0, 0.0);
+  const expectedTranslation = new Vector4(origin.x, origin.y, origin.z, 1.0);
+
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame('north', 'east', 'down', origin);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_Z); // north
+  t.deepEquals(returnedResult.getColumn(1), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(2), negativeX); // down
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northEastDownToFixedFrame works with a result parameter', t => {
+  const origin = new Vector3(1.0, 0.0, 0.0);
+  const expectedTranslation = new Vector4(origin.x, origin.y, origin.z, 1.0);
+  const result = new Matrix4(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame(
+    'north',
+    'east',
+    'down',
+    origin,
+    result
+  );
+  t.equals(result, returnedResult);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_Z); // north
+  t.deepEquals(returnedResult.getColumn(1), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(2), negativeX); // down
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northEastDownToFixedFrame works at the north pole', t => {
+  const northPole = new Vector3(0.0, 0.0, 1.0);
+  const expectedTranslation = new Vector4(northPole.x, northPole.y, northPole.z, 1.0);
+
+  const result = new Matrix4();
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame(
+    'north',
+    'east',
+    'down',
+    northPole,
+    result
+  );
+  t.equals(returnedResult, result);
+  t.deepEquals(returnedResult.getColumn(0), negativeX); // north
+  t.deepEquals(returnedResult.getColumn(1), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(2), negativeZ); // down
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northEastDownToFixedFrame works at the south pole', t => {
+  const southPole = new Vector3(0.0, 0.0, -1.0);
+  const expectedTranslation = new Vector4(southPole.x, southPole.y, southPole.z, 1.0);
+
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame('north', 'east', 'down', southPole);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_X); // north
+  t.deepEquals(returnedResult.getColumn(1), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(2), Vector4.UNIT_Z); // down
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northUpEastToFixedFrame works without a result parameter', t => {
+  const origin = new Vector3(1.0, 0.0, 0.0);
+  const expectedTranslation = new Vector4(origin.x, origin.y, origin.z, 1.0);
+
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame('north', 'up', 'east', origin);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_Z); // north
+  t.deepEquals(returnedResult.getColumn(1), Vector4.UNIT_X); // up
+  t.deepEquals(returnedResult.getColumn(2), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northUpEastToFixedFrame works with a result parameter', t => {
+  const origin = new Vector3(1.0, 0.0, 0.0);
+  const expectedTranslation = new Vector4(origin.x, origin.y, origin.z, 1.0);
+  const result = new Matrix4(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame('north', 'up', 'east', origin, result);
+  t.equals(result, returnedResult);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_Z); // north
+  t.deepEquals(returnedResult.getColumn(1), Vector4.UNIT_X); // up
+  t.deepEquals(returnedResult.getColumn(2), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northUpEastToFixedFrame works at the north pole', t => {
+  const northPole = new Vector3(0.0, 0.0, 1.0);
+  const expectedTranslation = new Vector4(northPole.x, northPole.y, northPole.z, 1.0);
+
+  const result = new Matrix4();
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame(
+    'north',
+    'up',
+    'east',
+    northPole,
+    result
+  );
+  t.equals(returnedResult, result);
+  t.deepEquals(returnedResult.getColumn(0), negativeX); // north
+  t.deepEquals(returnedResult.getColumn(1), Vector4.UNIT_Z); // up
+  t.deepEquals(returnedResult.getColumn(2), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northUpEastToFixedFrame works at the south pole', t => {
+  const southPole = new Vector3(0.0, 0.0, -1.0);
+  const expectedTranslation = new Vector4(southPole.x, southPole.y, southPole.z, 1.0);
+
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame('north', 'up', 'east', southPole);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_X); // north
+  t.deepEquals(returnedResult.getColumn(1), negativeZ); // up
+  t.deepEquals(returnedResult.getColumn(2), Vector4.UNIT_Y); // east
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northWestUpToFixedFrame works without a result parameter', t => {
+  const origin = new Vector3(1.0, 0.0, 0.0);
+  const expectedTranslation = new Vector4(origin.x, origin.y, origin.z, 1.0);
+
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame('north', 'west', 'up', origin);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_Z); // north
+  t.deepEquals(returnedResult.getColumn(1), negativeY); // west
+  t.deepEquals(returnedResult.getColumn(2), Vector4.UNIT_X); // up
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northWestUpToFixedFrame works with a result parameter', t => {
+  const origin = new Vector3(1.0, 0.0, 0.0);
+  const expectedTranslation = new Vector4(origin.x, origin.y, origin.z, 1.0);
+  const result = new Matrix4(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
+
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame('north', 'west', 'up', origin, result);
+  t.equals(result, returnedResult);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_Z); // north
+  t.deepEquals(returnedResult.getColumn(1), negativeY); // west
+  t.deepEquals(returnedResult.getColumn(2), Vector4.UNIT_X); // up
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northWestUpToFixedFrame works at the north pole', t => {
+  const northPole = new Vector3(0.0, 0.0, 1.0);
+  const expectedTranslation = new Vector4(northPole.x, northPole.y, northPole.z, 1.0);
+
+  const result = new Matrix4();
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame(
+    'north',
+    'west',
+    'up',
+    northPole,
+    result
+  );
+  t.equals(returnedResult, result);
+  t.deepEquals(returnedResult.getColumn(0), negativeX); // north
+  t.deepEquals(returnedResult.getColumn(1), negativeY); // west
+  t.deepEquals(returnedResult.getColumn(2), Vector4.UNIT_Z); // up
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+test('Ellipsoid#transforms#northWestUpToFixedFrame works at the south pole', t => {
+  const southPole = new Vector3(0.0, 0.0, -1.0);
+  const expectedTranslation = new Vector4(southPole.x, southPole.y, southPole.z, 1.0);
+
+  const returnedResult = UNIT_SPHERE.localFrameToFixedFrame('north', 'west', 'up', southPole);
+  t.deepEquals(returnedResult.getColumn(0), Vector4.UNIT_X); // north
+  t.deepEquals(returnedResult.getColumn(1), negativeY); // west
+  t.deepEquals(returnedResult.getColumn(2), negativeZ); // up
+  t.deepEquals(returnedResult.getColumn(3), expectedTranslation); // translation
+  t.end();
+});
+
+/*
+test('Ellipsoid#transforms#normal use of localFrameToFixedFrameGenerator', t => {
+  const cartesianTab = [
+    new Vector3(0.0, 0.0, 1.0),
+    new Vector3(0.0, 0.0, -1.0),
+    new Vector3(10.0, 20.0, 30.0),
+    new Vector3(-10.0, -20.0, -30.0),
+    new Vector3(-25.0, 60.0, -1.0),
+    new Vector3(9.0, 0.0, -7.0)
+  ];
+
+  const converterTab = [
+    {
+      converter : Transforms.localFrameToFixedFrameGenerator('north', 'east'),
+      order : ['north', 'east', 'down']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('north', 'west'),
+      order : ['north', 'west', 'up']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('north', 'up'),
+      order : ['north', 'up', 'east']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('north', 'down'),
+      order : ['north', 'down', 'west']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('south', 'east'),
+      order : ['south', 'east', 'up']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('south', 'west'),
+      order : ['south', 'west', 'down']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('south', 'up'),
+      order : ['south', 'up', 'west']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('south', 'down'),
+      order : ['south', 'down', 'east']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('east', 'north'),
+      order : ['east', 'north', 'up']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('east', 'south'),
+      order : ['east', 'south', 'down']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('east', 'up'),
+      order : ['east', 'up', 'south']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('east', 'down'),
+      order : ['east', 'down', 'north']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('west', 'north'),
+      order : ['west', 'north', 'down']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('west', 'south'),
+      order : ['west', 'south', 'up']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('west', 'up'),
+      order : ['west', 'up', 'north']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('west', 'down'),
+      order : ['west', 'down', 'south']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('up', 'north'),
+      order : ['up', 'north', 'west']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('up', 'south'),
+      order : ['up', 'south', 'east']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('up', 'east'),
+      order : ['up', 'east', 'north']
+    }, {
+      converter : Transforms.localFrameToFixedFrameGenerator('up', 'west'),
+      order : ['up', 'west', 'south']
+    }
+  ];
+
+  function testAllLocalFrame(classicalENUMatrix, position) {
+    const ENUColumn = new Vector4();
+    const converterColumn = new Vector4();
+    for (let i = 0; i < converterTab.length; i++) {
+      const converterMatrix = (converterTab[i].converter)(position, Ellipsoid.UNIT_SPHERE);
+      const order = converterTab[i].order;
+      // check translation
+      Matrix4.getColumn(classicalENUMatrix, 3, ENUColumn);
+      Matrix4.getColumn(converterMatrix, 3, converterColumn);
+      t.deepEquals(ENUColumn, converterColumn);
+      // check axis
+      for (let j = 0; j < 3; j++) {
+        Matrix4.getColumn(converterMatrix, j, converterColumn);
+        const axisName = order[j];
+        if (axisName === 'east') {
+          Matrix4.getColumn(classicalENUMatrix, 0, ENUColumn);
+        } else if (axisName === 'west') {
+          Matrix4.getColumn(classicalENUMatrix, 0, ENUColumn);
+          Vector4.negate(ENUColumn, ENUColumn);
+        } else if (axisName === 'north') {
+          Matrix4.getColumn(classicalENUMatrix, 1, ENUColumn);
+        } else if (axisName === 'south') {
+          Matrix4.getColumn(classicalENUMatrix, 1, ENUColumn);
+          Vector4.negate(ENUColumn, ENUColumn);
+        } else if (axisName === 'up') {
+          Matrix4.getColumn(classicalENUMatrix, 2, ENUColumn);
+        } else if (axisName === 'down') {
+          Matrix4.getColumn(classicalENUMatrix, 2, ENUColumn);
+          Vector4.negate(ENUColumn, ENUColumn);
+        }
+        t.deepEquals(ENUColumn, converterColumn);
+      }
+    }
+  }
+
+  for (let i = 0; i < cartesianTab.length; i++) {
+    const cartesian = cartesianTab[i];
+    const classicalEastNorthUpReferential = Transforms.eastNorthUpToFixedFrame(cartesian, Ellipsoid.UNIT_SPHERE);
+    testAllLocalFrame(classicalEastNorthUpReferential, cartesian);
+  }
+  t.end();
+});
+*/
+
+test('Ellipsoid#transforms#localFrameToFixedFrame incorrect use throws', t => {
+  const origin = [1, 0, 0];
+
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame(undefined, undefined, null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('north', undefined, null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame(undefined, 'north', null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('south', undefined, null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('northe', 'southe', null, origin));
+
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('north', 'north', null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('north', 'south', null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('south', 'north', null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('south', 'south', null, origin));
+
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('up', 'up', null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('up', 'down', null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('down', 'up', null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('down', 'down', null, origin));
+
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('east', 'east', null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('east', 'west', null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('west', 'east', null, origin));
+  t.throws(() => UNIT_SPHERE.localFrameToFixedFrame('west', 'west', null, origin));
+  t.end();
+});

--- a/modules/geospatial/test/ellipsoid/ellipsoid.bench.js
+++ b/modules/geospatial/test/ellipsoid/ellipsoid.bench.js
@@ -1,0 +1,86 @@
+import {Vector3, Matrix4} from 'math.gl';
+import {Ellipsoid} from '@math.gl/geospatial';
+// import {externalVector3ToArray, setExternalVector3} from '@math.gl/geospatial/type-utils';
+import * as vec3 from 'gl-matrix/vec3';
+
+const ellipsoid = Ellipsoid.WGS84;
+const spaceCartesian = new Vector3(4582719.8827300891, -4582719.8827300882, 1725510.4250797231);
+const spaceCartographic = new Vector3(-45.0, 15.0, 330000.0);
+const spaceCartographicObject = {x: -45.0, y: 15.0, z: 330000.0};
+const resultVector = new Vector3();
+const resultArray = [0, 0, 0];
+const resultObject = {x: 0, y: 0, z: 0};
+
+const origin = new Vector3(1.0, 0.0, 0.0);
+const northPole = new Vector3(0.0, 0.0, 1.0);
+const resultMatrix = new Matrix4();
+
+export default function ellipsoidBench(suite) {
+  // const spaceCartesian = new Vector3(4582719.8827300891, -4582719.8827300882, 1725510.4250797231);
+
+  suite
+    .group('Ellipsoid Major Operations')
+    .add('#cartographicToCartesian(=>Vector3)', () =>
+      ellipsoid.cartographicToCartesian(spaceCartographic, resultVector)
+    )
+    .add('#cartographicToCartesian(=>Object)', () =>
+      ellipsoid.cartographicToCartesian(spaceCartographic, resultObject)
+    )
+    .add('#cartesianToCartographic(=>Vector3)', () =>
+      ellipsoid.cartesianToCartographic(spaceCartesian, resultVector)
+    )
+    .add('#eastNorthUpToFixedFrame()', () =>
+      Ellipsoid.WGS84.eastNorthUpToFixedFrame(origin, resultMatrix)
+    )
+    .add('#eastNorthUpToFixedFrame(Pole)', () =>
+      Ellipsoid.WGS84.eastNorthUpToFixedFrame(northPole, resultMatrix)
+    )
+
+    .group('Ellipsoid Minor Operations')
+    .add('#geodSurfNormalCarto(=>Object)', () =>
+      ellipsoid.geodeticSurfaceNormalCartographic(spaceCartographicObject, resultObject)
+    )
+    .add('#geodSurfNormal(=>Vector3)', () =>
+      ellipsoid.geodeticSurfaceNormalCartographic(spaceCartographic, resultVector)
+    )
+    .add('#geodSurfNormalCarto() Opt', () =>
+      geodeticSurfaceNormalCartographicOptimized(spaceCartographic, resultArray)
+    )
+
+    .add('#geodeticSurfaceNormal(=>Vector3)', () =>
+      ellipsoid.geodeticSurfaceNormal(spaceCartesian, resultVector)
+    )
+
+    .add('#scaleToGeocentricSurface(=>Vector3)', () =>
+      ellipsoid.scaleToGeocentricSurface(spaceCartesian, resultVector)
+    )
+    .add('#scaleToGeocentricSurface(=>Object)', () =>
+      ellipsoid.scaleToGeocentricSurface(spaceCartesian, resultObject)
+    );
+
+  return suite;
+}
+
+// Hand optimized version of Ellipsoid.geodeticSurfaceNormalCartographic
+// Computes the normal of the plane tangent to the surface of the ellipsoid at provided position.
+function geodeticSurfaceNormalCartographicOptimized(cartographic, result = new Vector3()) {
+  // const longitude = cartographic.longitude;
+  // const latitude = cartographic.latitude;
+
+  // const longitude = toRadians(cartographic[0]);
+  // const latitude = toRadians(cartographic[1]);
+  const longitude = cartographic[0];
+  const latitude = cartographic[1];
+
+  const cosLatitude = Math.cos(latitude);
+
+  const x = cosLatitude * Math.cos(longitude);
+  const y = cosLatitude * Math.sin(longitude);
+  const z = Math.sin(latitude);
+
+  result.x = x;
+  result.y = y;
+  result.z = z;
+
+  return vec3.normalize(result, result);
+}

--- a/modules/geospatial/test/ellipsoid/ellipsoid.spec.js
+++ b/modules/geospatial/test/ellipsoid/ellipsoid.spec.js
@@ -427,44 +427,6 @@ test('Ellipsoid#scaleToGeocentricSurface throws with no cartesian', t => {
   t.end();
 });
 
-/*
-test('Ellipsoid#clone copies any object with the proper structure', t => {
-  const myEllipsoid = {
-    _radii: {x: 1.0, y: 2.0, z: 3.0},
-    _radiiSquared: {x: 4.0, y: 5.0, z: 6.0},
-    _radiiToTheFourth: {x: 7.0, y: 8.0, z: 9.0},
-    _oneOverRadii: {x: 10.0, y: 11.0, z: 12.0},
-    _oneOverRadiiSquared: {x: 13.0, y: 14.0, z: 15.0},
-    _minimumRadius: 16.0,
-    _maximumRadius: 17.0,
-    _centerToleranceSquared: 18.0
-  };
-
-  const cloned = Ellipsoid.clone(myEllipsoid);
-  t.ok(cloned instanceof Ellipsoid);
-  t.equals(cloned, myEllipsoid);
-  t.end();
-});
-
-test('Ellipsoid#clone uses result parameter if provided', t => {
-  const myEllipsoid = {
-    _radii: {x: 1.0, y: 2.0, z: 3.0},
-    _radiiSquared: {x: 4.0, y: 5.0, z: 6.0},
-    _radiiToTheFourth: {x: 7.0, y: 8.0, z: 9.0},
-    _oneOverRadii: {x: 10.0, y: 11.0, z: 12.0},
-    _oneOverRadiiSquared: {x: 13.0, y: 14.0, z: 15.0},
-    _minimumRadius: 16.0,
-    _maximumRadius: 17.0,
-    _centerToleranceSquared: 18.0
-  };
-
-  const result = new Ellipsoid();
-  const cloned = Ellipsoid.clone(myEllipsoid, result);
-  t.ok(cloned === result);
-  t.equals(cloned, myEllipsoid);
-  t.end();
-});
-
 test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis throws with no position', t => {
   t.throws(() => Ellipsoid.WGS84.getSurfaceNormalIntersectionWithZAxis(undefined));
   t.end();
@@ -486,7 +448,7 @@ test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis throws if the ellipsoid ha
 
 test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis works without a result parameter', t => {
   const ellipsoid = Ellipsoid.WGS84;
-  const cartographic = Cartographic.fromDegrees(35.23, 33.23);
+  const cartographic = [35.23, 33.23, 0]; // Cartographic.fromDegrees(35.23, 33.23);
   const cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
   const returnedResult = ellipsoid.getSurfaceNormalIntersectionWithZAxis(cartesianOnTheSurface);
   t.ok(returnedResult instanceof Vector3);
@@ -495,7 +457,7 @@ test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis works without a result par
 
 test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis works with a result parameter', t => {
   const ellipsoid = Ellipsoid.WGS84;
-  const cartographic = Cartographic.fromDegrees(35.23, 33.23);
+  const cartographic = [35.23, 33.23, 0]; // Cartographic.fromDegrees(35.23, 33.23);
   const cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
   const returnedResult = ellipsoid.getSurfaceNormalIntersectionWithZAxis(
     cartesianOnTheSurface,
@@ -508,7 +470,7 @@ test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis works with a result parame
 
 test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis returns undefined if the result is outside the ellipsoid with buffer parameter', t => {
   const ellipsoid = Ellipsoid.WGS84;
-  const cartographic = Cartographic.fromDegrees(35.23, 33.23);
+  const cartographic = [35.23, 33.23, 0]; // Cartographic.fromDegrees(35.23, 33.23);
   const cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
   const returnedResult = ellipsoid.getSurfaceNormalIntersectionWithZAxis(
     cartesianOnTheSurface,
@@ -522,7 +484,7 @@ test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis returns undefined if the r
   const majorAxis = 10;
   const minorAxis = 1;
   const ellipsoid = new Ellipsoid(majorAxis, majorAxis, minorAxis);
-  const cartographic = Cartographic.fromDegrees(45.0, 90.0);
+  const cartographic = [45.0, 90.0, 0]; // Cartographic.fromDegrees(45.0, 90.0);
   const cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
   const returnedResult = ellipsoid.getSurfaceNormalIntersectionWithZAxis(
     cartesianOnTheSurface,
@@ -532,9 +494,10 @@ test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis returns undefined if the r
   t.end();
 });
 
+/*
 test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis returns a result that is equal to a value that computed in a different way', t => {
   const ellipsoid = Ellipsoid.WGS84;
-  const cartographic = Cartographic.fromDegrees(35.23, 33.23);
+  const cartographic = [35.23, 33.23, 0]; // Cartographic.fromDegrees(35.23, 33.23);
   let cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
   const surfaceNormal = ellipsoid.geodeticSurfaceNormal(cartesianOnTheSurface);
   const magnitude = cartesianOnTheSurface.x / surfaceNormal.x;
@@ -587,12 +550,12 @@ test("getSurfaceNormalIntersectionWithZAxis returns a result that when it's used
 
   t.end();
 });
+*/
 
-test('Ellipsoid#ellipsoid is initialized with _squaredXOverSquaredZ property', t => {
+test('Ellipsoid#ellipsoid is initialized with squaredXOverSquaredZ property', t => {
   const ellipsoid = new Ellipsoid(4, 4, 3);
 
   const squaredXOverSquaredZ = ellipsoid.radiiSquared.x / ellipsoid.radiiSquared.z;
-  t.equals(ellipsoid._squaredXOverSquaredZ, squaredXOverSquaredZ);
+  t.equals(ellipsoid.squaredXOverSquaredZ, squaredXOverSquaredZ);
   t.end();
 });
-*/

--- a/modules/geospatial/test/ellipsoid/ellipsoid.spec.js
+++ b/modules/geospatial/test/ellipsoid/ellipsoid.spec.js
@@ -1,0 +1,598 @@
+/* eslint-disable */
+import test from 'tape-catch';
+import {Vector3, toRadians, toDegrees, _MathUtils} from 'math.gl';
+import {Cartographic, Ellipsoid} from '@math.gl/geospatial';
+import {tapeEquals, tapeEqualsEpsilon} from 'test/utils/tape-assertions';
+
+Vector3.ZERO = new Vector3(0, 0, 0);
+
+const radii = new Vector3(1.0, 2.0, 3.0);
+const radiiSquared = new Vector3(radii).multiply(radii);
+const radiiToTheFourth = new Vector3(radiiSquared).multiply(radiiSquared);
+const oneOverRadii = new Vector3(1 / radii.x, 1 / radii.y, 1 / radii.z);
+const oneOverRadiiSquared = new Vector3(1 / radiiSquared.x, 1 / radiiSquared.y, 1 / radiiSquared.z);
+const minimumRadius = 1.0;
+const maximumRadius = 3.0;
+
+// All values computes using STK Components
+const spaceCartesian = new Vector3(4582719.8827300891, -4582719.8827300882, 1725510.4250797231);
+const spaceCartesianGeodeticSurfaceNormal = new Vector3(
+  0.6829975339864266,
+  -0.68299753398642649,
+  0.25889908678270795
+);
+
+const spaceCartographic = new Vector3(-45.0, 15.0, 330000.0);
+const spaceCartographicGeodeticSurfaceNormal = new Vector3(
+  0.68301270189221941,
+  -0.6830127018922193,
+  0.25881904510252074
+);
+
+const surfaceCartesian = new Vector3(4094327.7921465295, 1909216.4044747739, 4487348.4088659193);
+const surfaceCartographic = new Vector3(25.0, 45.0, 0.0);
+
+test('Ellipsoid#default constructor creates zero Ellipsoid', t => {
+  const ellipsoid = new Ellipsoid();
+  tapeEquals(t, ellipsoid.radii, Vector3.ZERO);
+  tapeEquals(t, ellipsoid.radiiSquared, Vector3.ZERO);
+  tapeEquals(t, ellipsoid.radiiToTheFourth, Vector3.ZERO);
+  tapeEquals(t, ellipsoid.oneOverRadii, Vector3.ZERO);
+  tapeEquals(t, ellipsoid.oneOverRadiiSquared, Vector3.ZERO);
+  t.equals(ellipsoid.minimumRadius, 0.0);
+  t.equals(ellipsoid.maximumRadius, 0.0);
+  t.end();
+});
+
+test('Ellipsoid#constructor computes correct values', t => {
+  const ellipsoid = new Ellipsoid(radii.x, radii.y, radii.z);
+  tapeEquals(t, ellipsoid.radii, radii);
+  tapeEquals(t, ellipsoid.radiiSquared, radiiSquared);
+  tapeEquals(t, ellipsoid.radiiToTheFourth, radiiToTheFourth);
+  tapeEquals(t, ellipsoid.oneOverRadii, oneOverRadii);
+  tapeEquals(t, ellipsoid.oneOverRadiiSquared, oneOverRadiiSquared);
+  t.equals(ellipsoid.minimumRadius, minimumRadius);
+  t.equals(ellipsoid.maximumRadius, maximumRadius);
+  t.end();
+});
+
+test('Ellipsoid#fromVector3 computes correct values', t => {
+  const ellipsoid = Ellipsoid.fromVector3(radii);
+  tapeEquals(t, ellipsoid.radii, radii);
+  tapeEquals(t, ellipsoid.radiiSquared, radiiSquared);
+  tapeEquals(t, ellipsoid.radiiToTheFourth, radiiToTheFourth);
+  tapeEquals(t, ellipsoid.oneOverRadii, oneOverRadii);
+  tapeEquals(t, ellipsoid.oneOverRadiiSquared, oneOverRadiiSquared);
+  t.equals(ellipsoid.minimumRadius, minimumRadius);
+  t.equals(ellipsoid.maximumRadius, maximumRadius);
+  t.end();
+});
+
+test('Ellipsoid#geodeticSurfaceNormalCartographic works without a result parameter', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const returnedResult = ellipsoid.geodeticSurfaceNormalCartographic(spaceCartographic);
+  tapeEqualsEpsilon(
+    t,
+    returnedResult,
+    spaceCartographicGeodeticSurfaceNormal,
+    _MathUtils.EPSILON15
+  );
+  t.end();
+});
+
+test('Ellipsoid#geodeticSurfaceNormalCartographic works with a result parameter', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const result = new Vector3();
+  const returnedResult = ellipsoid.geodeticSurfaceNormalCartographic(spaceCartographic, result);
+  t.ok(returnedResult === result);
+  tapeEqualsEpsilon(
+    t,
+    returnedResult,
+    spaceCartographicGeodeticSurfaceNormal,
+    _MathUtils.EPSILON15
+  );
+  t.end();
+});
+
+test('Ellipsoid#geodeticSurfaceNormal works without a result parameter', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const returnedResult = ellipsoid.geodeticSurfaceNormal(spaceCartesian);
+  tapeEqualsEpsilon(t, returnedResult, spaceCartesianGeodeticSurfaceNormal, _MathUtils.EPSILON15);
+  t.end();
+});
+
+test('Ellipsoid#geodeticSurfaceNormal works with a result parameter', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const result = new Vector3();
+  const returnedResult = ellipsoid.geodeticSurfaceNormal(spaceCartesian, result);
+  t.ok(returnedResult === result);
+  tapeEqualsEpsilon(t, returnedResult, spaceCartesianGeodeticSurfaceNormal, _MathUtils.EPSILON15);
+  t.end();
+});
+
+test('Ellipsoid#cartographicToCartesian works without a result parameter', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const returnedResult = ellipsoid.cartographicToCartesian(spaceCartographic);
+  tapeEqualsEpsilon(t, returnedResult, spaceCartesian, _MathUtils.EPSILON7);
+  t.end();
+});
+
+test('Ellipsoid#cartographicToCartesian works with a result parameter', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const result = new Vector3();
+  const returnedResult = ellipsoid.cartographicToCartesian(spaceCartographic, result);
+  t.ok(result === returnedResult);
+  tapeEqualsEpsilon(t, returnedResult, spaceCartesian, _MathUtils.EPSILON7);
+  t.end();
+});
+
+test('Ellipsoid#cartographicToCartesian works with an Object result parameter', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const result = {x: 0, y: 0, z: 0};
+  const returnedResult = ellipsoid.cartographicToCartesian(spaceCartographic, result);
+  t.ok(result === returnedResult);
+  tapeEqualsEpsilon(t, returnedResult.x, spaceCartesian.x, _MathUtils.EPSILON7);
+  tapeEqualsEpsilon(t, returnedResult.y, spaceCartesian.y, _MathUtils.EPSILON7);
+  tapeEqualsEpsilon(t, returnedResult.z, spaceCartesian.z, _MathUtils.EPSILON7);
+  t.end();
+});
+
+test('Ellipsoid#cartesianToCartographic works without a result parameter', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const returnedResult = ellipsoid.cartesianToCartographic(surfaceCartesian);
+  tapeEqualsEpsilon(t, returnedResult, surfaceCartographic, _MathUtils.EPSILON8);
+  t.end();
+});
+
+test('Ellipsoid#cartesianToCartographic works with a result parameter', t => {
+  const result = new Vector3();
+  const returnedResult = Ellipsoid.WGS84.cartesianToCartographic(surfaceCartesian, result);
+  t.ok(result === returnedResult);
+  tapeEqualsEpsilon(t, returnedResult, surfaceCartographic, _MathUtils.EPSILON8);
+  t.end();
+});
+
+test('Ellipsoid#cartesianToCartographic works with an Object result parameter', t => {
+  const result = {x: 0, y: 0, z: 0};
+  const returnedResult = Ellipsoid.WGS84.cartesianToCartographic(surfaceCartesian, result);
+  t.ok(result === returnedResult);
+  tapeEqualsEpsilon(t, returnedResult.x, surfaceCartographic.x, _MathUtils.EPSILON8);
+  tapeEqualsEpsilon(t, returnedResult.y, surfaceCartographic.y, _MathUtils.EPSILON8);
+  tapeEqualsEpsilon(t, returnedResult.z, surfaceCartographic.z, _MathUtils.EPSILON8);
+  t.end();
+});
+
+test('Ellipsoid#cartesianToCartographic works with a Cartesian result parameter', t => {
+  const result = {longitude: 0, latitude: 0, height: 0};
+  const returnedResult = Ellipsoid.WGS84.cartesianToCartographic(surfaceCartesian, result);
+  t.ok(result === returnedResult);
+  tapeEqualsEpsilon(t, returnedResult.longitude, surfaceCartographic.x, _MathUtils.EPSILON8);
+  tapeEqualsEpsilon(t, returnedResult.latitude, surfaceCartographic.y, _MathUtils.EPSILON8);
+  tapeEqualsEpsilon(t, returnedResult.height, surfaceCartographic.z, _MathUtils.EPSILON8);
+  t.end();
+});
+
+test('Ellipsoid#cartesianToCartographic works close to center', t => {
+  const expected = new Vector3(
+    toDegrees(9.999999999999999e-11),
+    toDegrees(1.0067394967422763e-20),
+    -6378137.0
+  );
+  const returnedResult = Ellipsoid.WGS84.cartesianToCartographic(new Vector3(1e-50, 1e-60, 1e-70));
+  t.ok(returnedResult, expected);
+  t.end();
+});
+
+test('Ellipsoid#cartesianToCartographic return undefined very close to center', t => {
+  const returnedResult = Ellipsoid.WGS84.cartesianToCartographic(
+    new Vector3(1e-150, 1e-150, 1e-150)
+  );
+  t.equals(returnedResult, undefined);
+  t.end();
+});
+
+test('Ellipsoid#cartesianToCartographic return undefined at center', t => {
+  const returnedResult = Ellipsoid.WGS84.cartesianToCartographic(Vector3.ZERO);
+  t.equals(returnedResult, undefined);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeodeticSurface scaled in the x direction', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const expected = new Vector3(1.0, 0.0, 0.0);
+  const cartesian = new Vector3(9.0, 0.0, 0.0);
+  const returnedResult = ellipsoid.scaleToGeodeticSurface(cartesian);
+  t.deepEquals(returnedResult, expected);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeodeticSurface scaled in the y direction', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const expected = new Vector3(0.0, 2.0, 0.0);
+  const cartesian = new Vector3(0.0, 8.0, 0.0);
+  const returnedResult = ellipsoid.scaleToGeodeticSurface(cartesian);
+  t.deepEquals(returnedResult, expected);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeodeticSurface scaled in the z direction', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const expected = new Vector3(0.0, 0.0, 3.0);
+  const cartesian = new Vector3(0.0, 0.0, 8.0);
+  const returnedResult = ellipsoid.scaleToGeodeticSurface(cartesian);
+  t.deepEquals(returnedResult, expected);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeodeticSurface works without a result parameter', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const expected = new Vector3(0.2680893773941855, 1.1160466902266495, 2.3559801120411263);
+  const cartesian = new Vector3(4.0, 5.0, 6.0);
+  const returnedResult = ellipsoid.scaleToGeodeticSurface(cartesian);
+  tapeEqualsEpsilon(t, returnedResult, expected, _MathUtils.EPSILON16);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeodeticSurface works with a result parameter', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const expected = new Vector3(0.2680893773941855, 1.1160466902266495, 2.3559801120411263);
+  const cartesian = new Vector3(4.0, 5.0, 6.0);
+  const result = new Vector3();
+  const returnedResult = ellipsoid.scaleToGeodeticSurface(cartesian, result);
+  t.ok(returnedResult === result);
+  tapeEqualsEpsilon(t, result, expected, _MathUtils.EPSILON16);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeodeticSurface returns undefined at center', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const cartesian = new Vector3(0.0, 0.0, 0.0);
+  const returnedResult = ellipsoid.scaleToGeodeticSurface(cartesian);
+  t.equals(returnedResult, undefined);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeocentricSurface scaled in the x direction', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const expected = new Vector3(1.0, 0.0, 0.0);
+  const cartesian = new Vector3(9.0, 0.0, 0.0);
+  const returnedResult = ellipsoid.scaleToGeocentricSurface(cartesian);
+  t.deepEquals(returnedResult, expected);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeocentricSurface scaled in the y direction', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const expected = new Vector3(0.0, 2.0, 0.0);
+  const cartesian = new Vector3(0.0, 8.0, 0.0);
+  const returnedResult = ellipsoid.scaleToGeocentricSurface(cartesian);
+  t.deepEquals(returnedResult, expected);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeocentricSurface scaled in the z direction', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const expected = new Vector3(0.0, 0.0, 3.0);
+  const cartesian = new Vector3(0.0, 0.0, 8.0);
+  const returnedResult = ellipsoid.scaleToGeocentricSurface(cartesian);
+  t.deepEquals(returnedResult, expected);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeocentricSurface works without a result parameter', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const expected = new Vector3(0.7807200583588266, 0.9759000729485333, 1.1710800875382399);
+  const cartesian = new Vector3(4.0, 5.0, 6.0);
+  const returnedResult = ellipsoid.scaleToGeocentricSurface(cartesian);
+  tapeEqualsEpsilon(t, returnedResult, expected, _MathUtils.EPSILON16);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeocentricSurface works with a result parameter', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const expected = new Vector3(0.7807200583588266, 0.9759000729485333, 1.1710800875382399);
+  const cartesian = new Vector3(4.0, 5.0, 6.0);
+  const result = new Vector3();
+  const returnedResult = ellipsoid.scaleToGeocentricSurface(cartesian, result);
+  t.ok(returnedResult === result);
+  tapeEqualsEpsilon(t, result, expected, _MathUtils.EPSILON16);
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeocentricSurface works with an Object result parameter', t => {
+  const ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+  const expected = new Vector3(0.7807200583588266, 0.9759000729485333, 1.1710800875382399);
+  const cartesian = new Vector3(4.0, 5.0, 6.0);
+  const result = {x: 0, y: 0, z: 0};
+  const returnedResult = ellipsoid.scaleToGeocentricSurface(cartesian, result);
+  t.ok(returnedResult === result);
+  tapeEqualsEpsilon(t, result.x, expected.x, _MathUtils.EPSILON16);
+  tapeEqualsEpsilon(t, result.y, expected.y, _MathUtils.EPSILON16);
+  tapeEqualsEpsilon(t, result.z, expected.z, _MathUtils.EPSILON16);
+  t.end();
+});
+
+test('Ellipsoid#transformPositionToScaledSpace works without a result parameter', t => {
+  const ellipsoid = new Ellipsoid(2.0, 3.0, 4.0);
+  const expected = new Vector3(2.0, 2.0, 2.0);
+  const cartesian = new Vector3(4.0, 6.0, 8.0);
+  const returnedResult = ellipsoid.transformPositionToScaledSpace(cartesian);
+  tapeEqualsEpsilon(t, returnedResult, expected, _MathUtils.EPSILON16);
+  t.end();
+});
+
+test('Ellipsoid#transformPositionToScaledSpace works with a result parameter', t => {
+  const ellipsoid = new Ellipsoid(2.0, 3.0, 4.0);
+  const expected = new Vector3(3.0, 3.0, 3.0);
+  const cartesian = new Vector3(6.0, 9.0, 12.0);
+  const result = new Vector3();
+  const returnedResult = ellipsoid.transformPositionToScaledSpace(cartesian, result);
+  t.ok(returnedResult === result);
+  tapeEqualsEpsilon(t, result, expected, _MathUtils.EPSILON16);
+  t.end();
+});
+
+test('Ellipsoid#transformPositionFromScaledSpace works without a result parameter', t => {
+  const ellipsoid = new Ellipsoid(2.0, 3.0, 4.0);
+  const expected = new Vector3(4.0, 6.0, 8.0);
+  const cartesian = new Vector3(2.0, 2.0, 2.0);
+  const returnedResult = ellipsoid.transformPositionFromScaledSpace(cartesian);
+  tapeEqualsEpsilon(t, returnedResult, expected, _MathUtils.EPSILON16);
+  t.end();
+});
+
+test('Ellipsoid#transformPositionFromScaledSpace works with a result parameter', t => {
+  const ellipsoid = new Ellipsoid(2.0, 3.0, 4.0);
+  const expected = new Vector3(6.0, 9.0, 12.0);
+  const cartesian = new Vector3(3.0, 3.0, 3.0);
+  const result = new Vector3();
+  const returnedResult = ellipsoid.transformPositionFromScaledSpace(cartesian, result);
+  t.ok(returnedResult === result);
+  tapeEqualsEpsilon(t, result, expected, _MathUtils.EPSILON16);
+  t.end();
+});
+
+test('Ellipsoid#equals works in all cases', t => {
+  const ellipsoid = new Ellipsoid(1.0, 0.0, 0.0);
+  t.equals(ellipsoid.equals(new Ellipsoid(1.0, 0.0, 0.0)), true);
+  t.equals(ellipsoid.equals(new Ellipsoid(1.0, 1.0, 0.0)), false);
+  t.equals(ellipsoid.equals(undefined), false);
+  t.end();
+});
+
+test('Ellipsoid#toString produces expected values', t => {
+  const expected = '[1, 2, 3]';
+  const ellipsoid = new Ellipsoid(1, 2, 3);
+  t.equals(ellipsoid.toString(), expected);
+  t.end();
+});
+
+test('Ellipsoid#constructor throws if x less than 0', t => {
+  t.throws(() => new Ellipsoid(-1, 0, 0));
+  t.end();
+});
+
+test('Ellipsoid#constructor throws if y less than 0', t => {
+  t.throws(() => new Ellipsoid(0, -1, 0));
+  t.end();
+});
+
+test('Ellipsoid#constructor throws if z less than 0', t => {
+  t.throws(() => new Ellipsoid(0, 0, -1));
+  t.end();
+});
+
+test('Ellipsoid#geodeticSurfaceNormalCartographic throws with no cartographic', t => {
+  t.throws(() => Ellipsoid.WGS84.geodeticSurfaceNormalCartographic(undefined));
+  t.end();
+});
+
+test.skip('Ellipsoid#geocentricSurfaceNormal throws with no', t => {
+  t.throws(() => Ellipsoid.WGS84.geocentricSurfaceNormal(undefined));
+  t.end();
+});
+
+test('Ellipsoid#geodeticSurfaceNormal throws with no cartesian', t => {
+  t.throws(() => Ellipsoid.WGS84.geodeticSurfaceNormal(undefined));
+  t.end();
+});
+
+test('Ellipsoid#cartographicToCartesian throws with no cartographic', t => {
+  t.throws(() => Ellipsoid.WGS84.cartographicToCartesian(undefined));
+  t.end();
+});
+
+test('Ellipsoid#cartographicArrayToCartesianArray throws with no cartographics', t => {
+  t.throws(() => Ellipsoid.WGS84.cartographicArrayToCartesianArray(undefined));
+  t.end();
+});
+
+test('Ellipsoid#cartesianToCartographic throws with no cartesian', t => {
+  t.throws(() => Ellipsoid.WGS84.cartesianToCartographic(undefined));
+  t.end();
+});
+
+test('Ellipsoid#cartesianArrayToCartographicArray throws with no cartesians', t => {
+  t.throws(() => Ellipsoid.WGS84.cartesianArrayToCartographicArray(undefined));
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeodeticSurface throws with no cartesian', t => {
+  t.throws(() => Ellipsoid.WGS84.scaleToGeodeticSurface(undefined));
+  t.end();
+});
+
+test('Ellipsoid#scaleToGeocentricSurface throws with no cartesian', t => {
+  t.throws(() => Ellipsoid.WGS84.scaleToGeocentricSurface(undefined));
+  t.end();
+});
+
+/*
+test('Ellipsoid#clone copies any object with the proper structure', t => {
+  const myEllipsoid = {
+    _radii: {x: 1.0, y: 2.0, z: 3.0},
+    _radiiSquared: {x: 4.0, y: 5.0, z: 6.0},
+    _radiiToTheFourth: {x: 7.0, y: 8.0, z: 9.0},
+    _oneOverRadii: {x: 10.0, y: 11.0, z: 12.0},
+    _oneOverRadiiSquared: {x: 13.0, y: 14.0, z: 15.0},
+    _minimumRadius: 16.0,
+    _maximumRadius: 17.0,
+    _centerToleranceSquared: 18.0
+  };
+
+  const cloned = Ellipsoid.clone(myEllipsoid);
+  t.ok(cloned instanceof Ellipsoid);
+  t.equals(cloned, myEllipsoid);
+  t.end();
+});
+
+test('Ellipsoid#clone uses result parameter if provided', t => {
+  const myEllipsoid = {
+    _radii: {x: 1.0, y: 2.0, z: 3.0},
+    _radiiSquared: {x: 4.0, y: 5.0, z: 6.0},
+    _radiiToTheFourth: {x: 7.0, y: 8.0, z: 9.0},
+    _oneOverRadii: {x: 10.0, y: 11.0, z: 12.0},
+    _oneOverRadiiSquared: {x: 13.0, y: 14.0, z: 15.0},
+    _minimumRadius: 16.0,
+    _maximumRadius: 17.0,
+    _centerToleranceSquared: 18.0
+  };
+
+  const result = new Ellipsoid();
+  const cloned = Ellipsoid.clone(myEllipsoid, result);
+  t.ok(cloned === result);
+  t.equals(cloned, myEllipsoid);
+  t.end();
+});
+
+test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis throws with no position', t => {
+  t.throws(() => Ellipsoid.WGS84.getSurfaceNormalIntersectionWithZAxis(undefined));
+  t.end();
+});
+
+test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis throws if the ellipsoid is not an ellipsoid of revolution', t => {
+  const ellipsoid = new Ellipsoid(1, 2, 3);
+  const cartesian = new Vector3();
+  t.throws(() => ellipsoid.getSurfaceNormalIntersectionWithZAxis(cartesian));
+  t.end();
+});
+
+test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis throws if the ellipsoid has radii.z === 0', t => {
+  const ellipsoid = new Ellipsoid(1, 2, 0);
+  const cartesian = new Vector3();
+  t.throws(() => ellipsoid.getSurfaceNormalIntersectionWithZAxis(cartesian));
+  t.end();
+});
+
+test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis works without a result parameter', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const cartographic = Cartographic.fromDegrees(35.23, 33.23);
+  const cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
+  const returnedResult = ellipsoid.getSurfaceNormalIntersectionWithZAxis(cartesianOnTheSurface);
+  t.ok(returnedResult instanceof Vector3);
+  t.end();
+});
+
+test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis works with a result parameter', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const cartographic = Cartographic.fromDegrees(35.23, 33.23);
+  const cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
+  const returnedResult = ellipsoid.getSurfaceNormalIntersectionWithZAxis(
+    cartesianOnTheSurface,
+    undefined,
+    cartesianOnTheSurface
+  );
+  t.ok(returnedResult === cartesianOnTheSurface);
+  t.end();
+});
+
+test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis returns undefined if the result is outside the ellipsoid with buffer parameter', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const cartographic = Cartographic.fromDegrees(35.23, 33.23);
+  const cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
+  const returnedResult = ellipsoid.getSurfaceNormalIntersectionWithZAxis(
+    cartesianOnTheSurface,
+    ellipsoid.radii.z
+  );
+  t.ok(returnedResult === undefined);
+  t.end();
+});
+
+test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis returns undefined if the result is outside the ellipsoid without buffer parameter', t => {
+  const majorAxis = 10;
+  const minorAxis = 1;
+  const ellipsoid = new Ellipsoid(majorAxis, majorAxis, minorAxis);
+  const cartographic = Cartographic.fromDegrees(45.0, 90.0);
+  const cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
+  const returnedResult = ellipsoid.getSurfaceNormalIntersectionWithZAxis(
+    cartesianOnTheSurface,
+    undefined
+  );
+  t.ok(returnedResult === undefined);
+  t.end();
+});
+
+test('Ellipsoid#getSurfaceNormalIntersectionWithZAxis returns a result that is equal to a value that computed in a different way', t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const cartographic = Cartographic.fromDegrees(35.23, 33.23);
+  let cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
+  const surfaceNormal = ellipsoid.geodeticSurfaceNormal(cartesianOnTheSurface);
+  const magnitude = cartesianOnTheSurface.x / surfaceNormal.x;
+
+  const expected = new Vector3();
+  expected.z = cartesianOnTheSurface.z - surfaceNormal.z * magnitude;
+  let result = ellipsoid.getSurfaceNormalIntersectionWithZAxis(cartesianOnTheSurface, undefined);
+  tapeEqualsEpsilon(t, result, expected, _MathUtils.EPSILON8);
+
+  // at the equator
+  cartesianOnTheSurface = new Vector3(ellipsoid.radii.x, 0, 0);
+  result = ellipsoid.getSurfaceNormalIntersectionWithZAxis(cartesianOnTheSurface, undefined);
+  tapeEqualsEpsilon(t, result, Vector3.ZERO, _MathUtils.EPSILON8);
+
+  t.end();
+});
+
+test("getSurfaceNormalIntersectionWithZAxis returns a result that when it's used as an origin for a vector with the surface normal direction it produces an accurate cartographic", t => {
+  const ellipsoid = Ellipsoid.WGS84;
+  const cartographic = Cartographic.fromDegrees(35.23, 33.23);
+  const cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
+  const surfaceNormal = ellipsoid.geodeticSurfaceNormal(cartesianOnTheSurface);
+
+  const result = ellipsoid.getSurfaceNormalIntersectionWithZAxis(cartesianOnTheSurface, undefined);
+
+  const surfaceNormalWithLength = Vector3.multiplyByScalar(
+    surfaceNormal,
+    ellipsoid.maximumRadius,
+    new Vector3()
+  );
+  const position = Vector3.add(result, surfaceNormalWithLength, new Vector3());
+  const resultCartographic = ellipsoid.cartesianToCartographic(position);
+  resultCartographic.height = 0.0;
+  tapeEqualsEpsilon(t, resultCartographic, cartographic, _MathUtils.EPSILON8);
+
+  // at the north pole
+  cartographic = Cartographic.fromDegrees(0, 90);
+  cartesianOnTheSurface = new Vector3(0, 0, ellipsoid.radii.z);
+  surfaceNormal = ellipsoid.geodeticSurfaceNormal(cartesianOnTheSurface);
+  surfaceNormalWithLength = Vector3.multiplyByScalar(
+    surfaceNormal,
+    ellipsoid.maximumRadius,
+    new Vector3()
+  );
+  result = ellipsoid.getSurfaceNormalIntersectionWithZAxis(cartesianOnTheSurface, undefined);
+  position = Vector3.add(result, surfaceNormalWithLength, new Vector3());
+  resultCartographic = ellipsoid.cartesianToCartographic(position);
+  resultCartographic.height = 0.0;
+  tapeEqualsEpsilon(t, resultCartographic, cartographic, _MathUtils.EPSILON8);
+
+  t.end();
+});
+
+test('Ellipsoid#ellipsoid is initialized with _squaredXOverSquaredZ property', t => {
+  const ellipsoid = new Ellipsoid(4, 4, 3);
+
+  const squaredXOverSquaredZ = ellipsoid.radiiSquared.x / ellipsoid.radiiSquared.z;
+  t.equals(ellipsoid._squaredXOverSquaredZ, squaredXOverSquaredZ);
+  t.end();
+});
+*/

--- a/modules/geospatial/test/index.js
+++ b/modules/geospatial/test/index.js
@@ -1,0 +1,2 @@
+import './ellipsoid/ellipsoid.spec';
+import './ellipsoid/ellipsoid-transform.spec';

--- a/modules/geospatial/test/index.js
+++ b/modules/geospatial/test/index.js
@@ -1,2 +1,3 @@
+import './type-utils.spec';
 import './ellipsoid/ellipsoid.spec';
 import './ellipsoid/ellipsoid-transform.spec';

--- a/modules/geospatial/test/type-utils.spec.js
+++ b/modules/geospatial/test/type-utils.spec.js
@@ -13,11 +13,11 @@ const radianVector = [toRadians(45), toRadians(45), 10];
 test('type-utils#fromCartographic', t => {
   let result;
   result = fromCartographicToDegrees([45, 45, 10], [0, 0, 0]);
-  t.deepEquals(result, [45, 45, 10])
+  t.deepEquals(result, [45, 45, 10]);
   result = fromCartographicToDegrees({x: 45, y: 45, z: 10}, [0, 0, 0]);
-  t.deepEquals(result, [45, 45, 10])
+  t.deepEquals(result, [45, 45, 10]);
   result = fromCartographicToDegrees({longitude: 45, latitude: 45, height: 10}, [0, 0, 0]);
-  t.deepEquals(result, [45, 45, 10])
+  t.deepEquals(result, [45, 45, 10]);
 
   result = fromCartographicToRadians([45, 45, 10], [0, 0, 0]);
   t.deepEquals(result, radianVector);
@@ -32,18 +32,18 @@ test('type-utils#fromCartographic', t => {
 test('type-utils#toCartographic', t => {
   let result;
   result = toCartographicFromDegrees([45, 45, 10], [0, 0, 0]);
-  t.deepEquals(result, [45, 45, 10])
+  t.deepEquals(result, [45, 45, 10]);
   result = toCartographicFromDegrees([45, 45, 10], {x: 0, y: 0, z: 0});
-  t.deepEquals(result, {x: 45, y: 45, z: 10})
+  t.deepEquals(result, {x: 45, y: 45, z: 10});
   result = toCartographicFromDegrees([45, 45, 10], {longitude: 0, latitude: 0, height: 0});
-  t.deepEquals(result, {longitude: 45, latitude: 45, height: 10})
+  t.deepEquals(result, {longitude: 45, latitude: 45, height: 10});
 
   result = toCartographicFromRadians(radianVector, [0, 0, 0]);
-  t.deepEquals(result, [45, 45, 10])
+  t.deepEquals(result, [45, 45, 10]);
   result = toCartographicFromRadians(radianVector, {x: 0, y: 0, z: 0});
-  t.deepEquals(result, {x: 45, y: 45, z: 10})
+  t.deepEquals(result, {x: 45, y: 45, z: 10});
   result = toCartographicFromRadians(radianVector, {longitude: 0, latitude: 0, height: 0});
-  t.deepEquals(result, {longitude: 45, latitude: 45, height: 10})
+  t.deepEquals(result, {longitude: 45, latitude: 45, height: 10});
 
   t.end();
 });

--- a/modules/geospatial/test/type-utils.spec.js
+++ b/modules/geospatial/test/type-utils.spec.js
@@ -7,7 +7,6 @@ import {
   toCartographicFromDegrees
 } from '@math.gl/geospatial/type-utils';
 
-const degreeVector = [45, 45, 10];
 const radianVector = [toRadians(45), toRadians(45), 10];
 
 test('type-utils#fromCartographic', t => {

--- a/modules/geospatial/test/type-utils.spec.js
+++ b/modules/geospatial/test/type-utils.spec.js
@@ -1,0 +1,49 @@
+import test from 'tape-catch';
+import {toRadians} from 'math.gl';
+import {
+  fromCartographicToRadians,
+  fromCartographicToDegrees,
+  toCartographicFromRadians,
+  toCartographicFromDegrees
+} from '@math.gl/geospatial/type-utils';
+
+const degreeVector = [45, 45, 10];
+const radianVector = [toRadians(45), toRadians(45), 10];
+
+test('type-utils#fromCartographic', t => {
+  let result;
+  result = fromCartographicToDegrees([45, 45, 10], [0, 0, 0]);
+  t.deepEquals(result, [45, 45, 10])
+  result = fromCartographicToDegrees({x: 45, y: 45, z: 10}, [0, 0, 0]);
+  t.deepEquals(result, [45, 45, 10])
+  result = fromCartographicToDegrees({longitude: 45, latitude: 45, height: 10}, [0, 0, 0]);
+  t.deepEquals(result, [45, 45, 10])
+
+  result = fromCartographicToRadians([45, 45, 10], [0, 0, 0]);
+  t.deepEquals(result, radianVector);
+  result = fromCartographicToRadians({x: 45, y: 45, z: 10}, [0, 0, 0]);
+  t.deepEquals(result, radianVector);
+  result = fromCartographicToRadians({longitude: 45, latitude: 45, height: 10}, [0, 0, 0]);
+  t.deepEquals(result, radianVector);
+
+  t.end();
+});
+
+test('type-utils#toCartographic', t => {
+  let result;
+  result = toCartographicFromDegrees([45, 45, 10], [0, 0, 0]);
+  t.deepEquals(result, [45, 45, 10])
+  result = toCartographicFromDegrees([45, 45, 10], {x: 0, y: 0, z: 0});
+  t.deepEquals(result, {x: 45, y: 45, z: 10})
+  result = toCartographicFromDegrees([45, 45, 10], {longitude: 0, latitude: 0, height: 0});
+  t.deepEquals(result, {longitude: 45, latitude: 45, height: 10})
+
+  result = toCartographicFromRadians(radianVector, [0, 0, 0]);
+  t.deepEquals(result, [45, 45, 10])
+  result = toCartographicFromRadians(radianVector, {x: 0, y: 0, z: 0});
+  t.deepEquals(result, {x: 45, y: 45, z: 10})
+  result = toCartographicFromRadians(radianVector, {longitude: 0, latitude: 0, height: 0});
+  t.deepEquals(result, {longitude: 45, latitude: 45, height: 10})
+
+  t.end();
+});

--- a/test/bench.js
+++ b/test/bench.js
@@ -23,10 +23,12 @@ require('reify');
 
 const {Bench} = require('@probe.gl/bench');
 const coreBench = require('math.gl/test/bench').default;
+const geospatialBench = require('@math.gl/geospatial/test/bench').default;
 
 const suite = new Bench();
 
 coreBench(suite);
+geospatialBench(suite);
 
 suite
   // Calibrate performance

--- a/test/index.js
+++ b/test/index.js
@@ -20,3 +20,4 @@
 
 require('reify');
 require('../modules/core/test');
+require('../modules/geospatial/test');


### PR DESCRIPTION
# For #67 ([RFC](https://github.com/uber-web/math.gl/blob/HEAD@%7B2019-05-29T20:29:53Z%7D/dev-docs/RFCs/geospatial-module-rfc.md))

Adds a new module `@math.gl/geospatial` and seeds it with the central `Ellipsoid` class, which supports conversion between WSG84 cartesian and cartographic representations, as well as calculations of local transformations at given points on the ellipsoid.

This PR is part of the ongoing collaboration with Cesium on supporting 3D tiles in loaders.gl.

@lilleyse @loshjawrence

Close to 100% test coverage for the new module: <img width="592" alt="Screen Shot 2019-05-29 at 1 27 28 PM" src="https://user-images.githubusercontent.com/7025232/58588891-8b081e80-8215-11e9-86e2-42ea19c30052.png">
