### PR TITLE
[Fix] getFlyToDuration returns NaN when transitioning to same viewport center

### DIFF
--- a/modules/web-mercator/docs/api-reference/web-mercator-utils.md
+++ b/modules/web-mercator/docs/api-reference/web-mercator-utils.md
@@ -229,6 +229,3 @@ Parameters:
 
 Returns:
 - `duration` Number, in milliseconds.
-
-NOTES:
-- '0' will be returned when `longitude` and `latitude` of `startProps` and `endProps` are same.

--- a/modules/web-mercator/docs/api-reference/web-mercator-utils.md
+++ b/modules/web-mercator/docs/api-reference/web-mercator-utils.md
@@ -229,3 +229,6 @@ Parameters:
 
 Returns:
 - `duration` Number, in milliseconds.
+
+NOTES:
+- '0' will be returned when `longitude` and `latitude` of `startProps` and `endProps` are same.

--- a/modules/web-mercator/src/fly-to-viewport.js
+++ b/modules/web-mercator/src/fly-to-viewport.js
@@ -27,7 +27,7 @@ export default function flyToViewport(startProps, endProps, t, opts = {}) {
   );
 
   // If change in center is too small, do linear interpolaiton.
-  if (Math.abs(u1) < EPSILON) {
+  if (u1 < EPSILON) {
     for (const key of VIEWPORT_TRANSITION_PROPS) {
       const startValue = startProps[key];
       const endValue = endProps[key];
@@ -58,11 +58,7 @@ export default function flyToViewport(startProps, endProps, t, opts = {}) {
 export function getFlyToDuration(startProps, endProps, opts = {}) {
   opts = Object.assign({}, DEFAULT_OPTS, opts);
   const {screenSpeed, speed, maxDuration} = opts;
-  const {S, rho, u1} = getFlyToTransitionParams(startProps, endProps, opts);
-  if (u1 === 0) {
-    // No change in viewport center
-    return 0;
-  }
+  const {S, rho} = getFlyToTransitionParams(startProps, endProps, opts);
   const length = 1000 * S;
   let duration;
   if (Number.isFinite(screenSpeed)) {
@@ -96,10 +92,13 @@ function getFlyToTransitionParams(startProps, endProps, opts) {
   const u1 = vec2.length(uDelta) * startScale;
   // u0 is treated as '0' in Eq (9).
 
+  // If u1 is too small, will generate invalid number
+  const _u1 = Math.max(u1, EPSILON);
+
   // Implement Equation (9) from above algorithm.
   const rho2 = rho * rho;
-  const b0 = (w1 * w1 - w0 * w0 + rho2 * rho2 * u1 * u1) / (2 * w0 * rho2 * u1);
-  const b1 = (w1 * w1 - w0 * w0 - rho2 * rho2 * u1 * u1) / (2 * w1 * rho2 * u1);
+  const b0 = (w1 * w1 - w0 * w0 + rho2 * rho2 * _u1 * _u1) / (2 * w0 * rho2 * _u1);
+  const b1 = (w1 * w1 - w0 * w0 - rho2 * rho2 * _u1 * _u1) / (2 * w1 * rho2 * _u1);
   const r0 = Math.log(Math.sqrt(b0 * b0 + 1) - b0);
   const r1 = Math.log(Math.sqrt(b1 * b1 + 1) - b1);
   const S = (r1 - r0) / rho;

--- a/modules/web-mercator/src/fly-to-viewport.js
+++ b/modules/web-mercator/src/fly-to-viewport.js
@@ -58,7 +58,11 @@ export default function flyToViewport(startProps, endProps, t, opts = {}) {
 export function getFlyToDuration(startProps, endProps, opts = {}) {
   opts = Object.assign({}, DEFAULT_OPTS, opts);
   const {screenSpeed, speed, maxDuration} = opts;
-  const {S, rho} = getFlyToTransitionParams(startProps, endProps, opts);
+  const {S, rho, u1} = getFlyToTransitionParams(startProps, endProps, opts);
+  if (u1 === 0) {
+    // No change in viewport center
+    return 0;
+  }
   const length = 1000 * S;
   let duration;
   if (Number.isFinite(screenSpeed)) {

--- a/modules/web-mercator/test/spec/fly-to-viewport.spec.js
+++ b/modules/web-mercator/test/spec/fly-to-viewport.spec.js
@@ -83,6 +83,12 @@ const DURATION_TEST_CASES = [
     endProps: END_PROPS,
     opts: {maxDuration: 5000},
     expect: 0
+  },
+  {
+    title: 'duration to the same view state',
+    startProps: START_PROPS,
+    endProps: START_PROPS,
+    expect: 0
   }
 ];
 
@@ -95,7 +101,7 @@ test('flyToViewport', t => {
   t.end();
 });
 
-test('getFlyToDuration', t => {
+test.only('getFlyToDuration', t => {
   DURATION_TEST_CASES.forEach(testCase => {
     const duration = getFlyToDuration(testCase.startProps, testCase.endProps, testCase.opts);
     t.deepEqual(

--- a/modules/web-mercator/test/spec/fly-to-viewport.spec.js
+++ b/modules/web-mercator/test/spec/fly-to-viewport.spec.js
@@ -101,7 +101,7 @@ test('flyToViewport', t => {
   t.end();
 });
 
-test.only('getFlyToDuration', t => {
+test('getFlyToDuration', t => {
   DURATION_TEST_CASES.forEach(testCase => {
     const duration = getFlyToDuration(testCase.startProps, testCase.endProps, testCase.opts);
     t.deepEqual(

--- a/modules/web-mercator/test/spec/fly-to-viewport.spec.js
+++ b/modules/web-mercator/test/spec/fly-to-viewport.spec.js
@@ -88,7 +88,13 @@ const DURATION_TEST_CASES = [
     title: 'duration to the same view state',
     startProps: START_PROPS,
     endProps: START_PROPS,
-    expect: 0
+    expect: 0.014729167
+  },
+  {
+    title: 'duration to the same location with different zoom',
+    startProps: START_PROPS,
+    endProps: {...START_PROPS, zoom: 10},
+    expect: 817.01417
   }
 ];
 


### PR DESCRIPTION
Return `0` when transitioning to same viewport center.