### PR TITLE
web-mercator: pass typescript linter

### DIFF
--- a/modules/web-mercator/src/fit-bounds.js
+++ b/modules/web-mercator/src/fit-bounds.js
@@ -14,14 +14,15 @@ import assert from './assert';
  * Returns map settings {latitude, longitude, zoom}
  * that will contain the provided corners within the provided width.
  * Only supports non-perspective mode.
- * @param {Number} width - viewport width
- * @param {Number} height - viewport height
- * @param {Array} bounds - [[lon, lat], [lon, lat]]
- * @param {Array} minExtent - The width/height of the bounded area will never be smaller than this
- * @param {Number|PaddingObject} [padding] - The amount of padding in pixels
+ * @param {Object} options
+ * @param {Number} options.width - viewport width
+ * @param {Number} options.height - viewport height
+ * @param {Array} options.bounds - [[lon, lat], [lon, lat]]
+ * @param {Array} [options.minExtent] - The width/height of the bounded area will never be smaller than this
+ * @param {Number|Object} [options.padding] - The amount of padding in pixels
  *  to add to the given bounds. Can also be an object with top, bottom, left and right
  *  properties defining the padding.
- * @param {Array} [offset] - The center of the given bounds relative to the map's center,
+ * @param {Array} [options.offset] - The center of the given bounds relative to the map's center,
  *    [x, y] measured in pixels.
  * @returns {Object} - latitude, longitude and zoom
  */

--- a/modules/web-mercator/src/viewport.js
+++ b/modules/web-mercator/src/viewport.js
@@ -17,8 +17,6 @@ export default class Viewport {
    *
    * @class
    * @param {Object} opt - options
-   * @param {Boolean} mercator=true - Whether to use mercator projection
-   *
    * @param {Number} opt.width=1 - Width of "viewport" or window
    * @param {Number} opt.height=1 - Height of "viewport" or window
    * @param {Array} opt.center=[0, 0] - Center of viewport
@@ -86,6 +84,7 @@ export default class Viewport {
     this.pixelUnprojectionMatrix = mInverse;
 
     // Bind methods for easy access
+    /* eslint-disable @typescript-eslint/unbound-method */
     this.equals = this.equals.bind(this);
     this.project = this.project.bind(this);
     this.unproject = this.unproject.bind(this);
@@ -93,8 +92,8 @@ export default class Viewport {
     this.unprojectPosition = this.unprojectPosition.bind(this);
     this.projectFlat = this.projectFlat.bind(this);
     this.unprojectFlat = this.unprojectFlat.bind(this);
+    /* eslint-enable @typescript-eslint/unbound-method */
   }
-  /* eslint-enable complexity */
 
   // Two viewports are equal if width and height are identical, and if
   // their view and projection matrices are (approximately) equal.
@@ -180,7 +179,7 @@ export default class Viewport {
    * @param {Array} xyz - map coordinates
    * @return {Array} [x,y,z] world coordinates.
    */
-  projectFlat(xyz, scale = this.scale) {
+  projectFlat(xyz) {
     return xyz;
   }
 
@@ -191,7 +190,7 @@ export default class Viewport {
    * @param {Array} xyz - world coordinates
    * @return {Array} [x,y,z] map coordinates.
    */
-  unprojectFlat(xyz, scale = this.scale) {
+  unprojectFlat(xyz) {
     return xyz;
   }
 }

--- a/modules/web-mercator/src/web-mercator-utils.js
+++ b/modules/web-mercator/src/web-mercator-utils.js
@@ -52,9 +52,9 @@ export function lngLatToWorld([lng, lat]) {
 /**
  * Unproject world point [x,y] on map onto {lat, lon} on sphere
  *
- * @param {object|Vector} xy - object with {x,y} members
+ * @param {number[]} xy - array with [x,y] members
  *  representing point on projected map plane
- * @return {GeoCoordinates} - object with {lat,lon} of point on sphere.
+ * @return {number[]} - array with [x,y] of point on sphere.
  *   Has toArray method if you need a GeoJSON Array.
  *   Per cartographic tradition, lat and lon are specified as degrees.
  */

--- a/modules/web-mercator/src/web-mercator-viewport.js
+++ b/modules/web-mercator/src/web-mercator-viewport.js
@@ -24,17 +24,17 @@ export default class WebMercatorViewport extends Viewport {
    * @class
    * @param {Object} opt - options
    *
-   * @param {Number} opt.width=1 - Width of "viewport" or window
-   * @param {Number} opt.height=1 - Height of "viewport" or window
-   * @param {Number} opt.scale=1 - Either use scale or zoom
-   * @param {Number} opt.pitch=0 - Camera angle in degrees (0 is straight down)
-   * @param {Number} opt.bearing=0 - Map rotation in degrees (0 means north is up)
-   * @param {Number} opt.altitude= - Altitude of camera in screen units
+   * @param {Number} [opt.width=1] - Width of "viewport" or window
+   * @param {Number} [opt.height=1] - Height of "viewport" or window
+   * @param {Number} [opt.scale=1] - Either use scale or zoom
+   * @param {Number} [opt.pitch=0] - Camera angle in degrees (0 is straight down)
+   * @param {Number} [opt.bearing=0] - Map rotation in degrees (0 means north is up)
+   * @param {Number} [opt.altitude=] - Altitude of camera in screen units
    *
    * Web mercator projection short-hand parameters
-   * @param {Number} opt.latitude - Center of viewport on map (alternative to opt.center)
-   * @param {Number} opt.longitude - Center of viewport on map (alternative to opt.center)
-   * @param {Number} opt.zoom - Scale = Math.pow(2,zoom) on map (alternative to opt.scale)
+   * @param {Number} opt.latitude - Center of viewport on map
+   * @param {Number} opt.longitude - Center of viewport on map
+   * @param {Number} opt.zoom - Scale = Math.pow(2,zoom) on map
 
    * Notes:
    *  - Only one of center or [latitude, longitude] can be specified
@@ -123,9 +123,9 @@ export default class WebMercatorViewport extends Viewport {
   /**
    * Unproject world point [x,y] on map onto {lat, lon} on sphere
    *
-   * @param {object|Vector} xy - object with {x,y} members
+   * @param {number[]} xy - array with [x,y] members
    *  representing point on projected map plane
-   * @return {GeoCoordinates} - object with {lat,lon} of point on sphere.
+   * @return {number[]} - array with [lat,lon] of point on sphere.
    *   Has toArray method if you need a GeoJSON Array.
    *   Per cartographic tradition, lat and lon are specified as degrees.
    */
@@ -137,11 +137,12 @@ export default class WebMercatorViewport extends Viewport {
    * Get the map center that place a given [lng, lat] coordinate at screen
    * point [x, y]
    *
-   * @param {Array} lngLat - [lng,lat] coordinates
+   * @param {object} opt
+   * @param {number[]} opt.lngLat - [lng,lat] coordinates
    *   Specifies a point on the sphere.
-   * @param {Array} pos - [x,y] coordinates
+   * @param {number[]} opt.pos - [x,y] coordinates
    *   Specifies a point on the screen.
-   * @return {Array} [lng,lat] new map center.
+   * @return {number[]} [lng,lat] new map center.
    */
   getMapCenterByLngLatPosition({lngLat, pos}) {
     const fromLocation = pixelsToWorld(pos, this.pixelUnprojectionMatrix);
@@ -150,7 +151,7 @@ export default class WebMercatorViewport extends Viewport {
     const translate = vec2.add([], toLocation, vec2.negate([], fromLocation));
     const newCenter = vec2.add([], this.center, translate);
 
-    return worldToLngLat(newCenter, this.scale);
+    return worldToLngLat(newCenter);
   }
 
   // Legacy method name
@@ -162,6 +163,7 @@ export default class WebMercatorViewport extends Viewport {
    * Returns a new viewport that fit around the given rectangle.
    * Only supports non-perspective mode.
    * @param {Array} bounds - [[lon, lat], [lon, lat]]
+   * @param {Object} [options]
    * @param {Number} [options.padding] - The amount of padding in pixels to add to the given bounds.
    * @param {Array} [options.offset] - The center of the given bounds relative to the map's center,
    *    [x, y] measured in pixels.

--- a/modules/web-mercator/test/browser.js
+++ b/modules/web-mercator/test/browser.js
@@ -1,3 +1,3 @@
-require('tap-browser-color')();
-
+/* eslint-disable @typescript-eslint/no-var-requires */
+// require('tap-browser-color')();
 require('./index');

--- a/modules/web-mercator/test/fp32-limits.js
+++ b/modules/web-mercator/test/fp32-limits.js
@@ -43,8 +43,8 @@ test('FP32 & Offset Comparison', t => {
 
       // Calculate real position
       const realPixelPos = [
-        lngLatToWorld(point, scale)[0] - lngLatToWorld([longitude, latitude], scale)[0],
-        -(lngLatToWorld(point, scale)[1] - lngLatToWorld([longitude, latitude], scale)[1])
+        lngLatToWorld(point)[0] - lngLatToWorld([longitude, latitude])[0],
+        -(lngLatToWorld(point)[1] - lngLatToWorld([longitude, latitude])[1])
       ];
 
       // Calculate using FP32 mode
@@ -52,11 +52,11 @@ test('FP32 & Offset Comparison', t => {
       const latitudeFP32 = Math.fround(latitude);
       const pointFP32 = point.map(f => Math.fround(f));
       const coordsFP32 = [
-        Math.fround(lngLatToWorld(pointFP32, scale)[0]) -
-          Math.fround(lngLatToWorld([longitudeFP32, latitudeFP32], scale)[0]),
+        Math.fround(lngLatToWorld(pointFP32)[0]) -
+          Math.fround(lngLatToWorld([longitudeFP32, latitudeFP32])[0]),
         -(
-          Math.fround(lngLatToWorld(pointFP32, scale)[1]) -
-          Math.fround(lngLatToWorld([longitudeFP32, latitudeFP32], scale)[1])
+          Math.fround(lngLatToWorld(pointFP32)[1]) -
+          Math.fround(lngLatToWorld([longitudeFP32, latitudeFP32])[1])
         )
       ];
 
@@ -84,12 +84,8 @@ test('FP32 & Offset Comparison', t => {
 
       // We need to recalculate the "real" one because we re-centered
       const realPixelPos2 = [
-        lngLatToWorld(point, scale)[0] -
-          lngLatToWorld([centerPointFP32[0], centerPointFP32[1]], scale)[0],
-        -(
-          lngLatToWorld(point, scale)[1] -
-          lngLatToWorld([centerPointFP32[0], centerPointFP32[1]], scale)[1]
-        )
+        lngLatToWorld(point)[0] - lngLatToWorld([centerPointFP32[0], centerPointFP32[1]])[0],
+        -(lngLatToWorld(point)[1] - lngLatToWorld([centerPointFP32[0], centerPointFP32[1]])[1])
       ];
 
       t.comment(`- Offset Coordinates FP32+64: ${getDiff(offsetPixelPos, realPixelPos2).message}`);

--- a/modules/web-mercator/test/node.js
+++ b/modules/web-mercator/test/node.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 // Note: This script is started from root: cwd is not this folder
 const SRC_DIR = './src';
 

--- a/modules/web-mercator/test/spec/mercator-project-unproject.spec.js
+++ b/modules/web-mercator/test/spec/mercator-project-unproject.spec.js
@@ -1,6 +1,6 @@
 import {WebMercatorViewport} from '@math.gl/web-mercator';
 import test from 'tape-catch';
-import {config, equals} from 'math.gl';
+import {config, equals} from '@math.gl/core';
 
 const viewportProps = {
   latitude: 37.75,

--- a/modules/web-mercator/test/spec/normalize-viewport-props.spec.js
+++ b/modules/web-mercator/test/spec/normalize-viewport-props.spec.js
@@ -1,6 +1,6 @@
 import test from 'tape-catch';
 import {normalizeViewportProps} from '@math.gl/web-mercator';
-import {config, equals} from 'math.gl';
+import {config, equals} from '@math.gl/core';
 
 const NORMALIZATION_TEST_CASES = [
   [

--- a/modules/web-mercator/test/spec/versus-mapbox/mapbox-transform.js
+++ b/modules/web-mercator/test/spec/versus-mapbox/mapbox-transform.js
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// @ts-nocheck
+
 // NOTE: Transform is not a public API so we should be careful to always lock
 // down mapbox-gl to a specific major, minor, and patch version.
 import {Map, LngLat, Point} from './mapbox';

--- a/modules/web-mercator/test/spec/versus-mapbox/mapbox.js
+++ b/modules/web-mercator/test/spec/versus-mapbox/mapbox.js
@@ -1,4 +1,5 @@
-/* global global,window */
+// @ts-nocheck
+/* global global, window */
 let mapbox;
 
 function noop() {}

--- a/modules/web-mercator/test/spec/versus-mapbox/versus-mapbox.spec.js
+++ b/modules/web-mercator/test/spec/versus-mapbox/versus-mapbox.spec.js
@@ -3,7 +3,7 @@ import {MapboxTransform} from './mapbox-transform';
 import {WebMercatorViewport} from '@math.gl/web-mercator';
 import test from 'tape-catch';
 import {toLowPrecision} from '../../utils/test-utils';
-import {equals, config} from 'math.gl';
+import {equals, config} from '@math.gl/core';
 
 import VIEWPORT_PROPS from '../../utils/sample-viewports';
 

--- a/modules/web-mercator/test/spec/web-mercator-utils.spec.js
+++ b/modules/web-mercator/test/spec/web-mercator-utils.spec.js
@@ -1,7 +1,7 @@
 import test from 'tape-catch';
 import destination from '@turf/destination';
 import {toLowPrecision} from '../utils/test-utils';
-import {config, equals} from 'math.gl';
+import {config, equals} from '@math.gl/core';
 
 import {
   lngLatToWorld,

--- a/modules/web-mercator/test/spec/web-mercator-viewport.spec.js
+++ b/modules/web-mercator/test/spec/web-mercator-viewport.spec.js
@@ -1,6 +1,6 @@
 import test from 'tape-catch';
 import {WebMercatorViewport} from '@math.gl/web-mercator';
-import {equals, config} from 'math.gl';
+import {equals, config} from '@math.gl/core';
 
 import VIEWPORT_PROPS from '../utils/sample-viewports';
 

--- a/modules/web-mercator/test/utils/test-utils.js
+++ b/modules/web-mercator/test/utils/test-utils.js
@@ -1,9 +1,9 @@
 /**
  * Covert all numbers in a deep structure to a given precision, allowing
  * reliable float comparisons. Converts data in-place.
- * @param  {mixed} input      Input data
+ * @param  {any} input      Input data
  * @param  {Number} [precision] Desired precision
- * @return {mixed}            Input data, with all numbers converted
+ * @return {any}            Input data, with all numbers converted
  */
 export function toLowPrecision(input, precision = 11) {
   /* eslint-disable guard-for-in */

--- a/modules/web-mercator/test/webpack.config.js
+++ b/modules/web-mercator/test/webpack.config.js
@@ -1,3 +1,5 @@
+// @ts-nocheck
+/* eslint-disable @typescript-eslint/no-var-requires */
 const {resolve} = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -60,6 +62,7 @@ function getDist(env) {
 }
 
 const CONFIGS = {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   test: env =>
     Object.assign({}, TEST_CONFIG, {
       // Bundle the tests for running in the browser
@@ -69,6 +72,7 @@ const CONFIGS = {
       // plugins: [new HtmlWebpackPlugin()]
     }),
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   bench: env =>
     Object.assign({}, TEST_CONFIG, {
       entry: {
@@ -78,6 +82,7 @@ const CONFIGS = {
       plugins: [new HtmlWebpackPlugin()]
     }),
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: env =>
     Object.assign({}, TEST_CONFIG, {
       // Bundle the tests for running in the browser
@@ -87,6 +92,7 @@ const CONFIGS = {
       plugins: [new HtmlWebpackPlugin()]
     }),
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   renderReact: env =>
     Object.assign({}, TEST_CONFIG, {
       // Bundle the tests for running in the browser


### PR DESCRIPTION
These are changes that will make the web-mercator module pass the coming typescript introduction PR.

@Pessimistress Since this PR removes the unused scale parameter, I thought it might be good for you to give it a quick review, so I separated this from the other chunk of linter fixes.