### PR TITLE
Web mercator: Use input x component with unitsPerMeter2's x component

### DIFF
--- a/modules/web-mercator/src/web-mercator-utils.js
+++ b/modules/web-mercator/src/web-mercator-utils.js
@@ -148,7 +148,7 @@ export function addMetersToLngLat(lngLatZ, xyz) {
   });
 
   const worldspace = lngLatToWorld(lngLatZ);
-  worldspace[0] += x * (unitsPerMeter[0] + unitsPerMeter2[0] * y);
+  worldspace[0] += x * (unitsPerMeter[0] + unitsPerMeter2[0] * x);
   worldspace[1] += y * (unitsPerMeter[1] + unitsPerMeter2[1] * y);
 
   const newLngLat = worldToLngLat(worldspace);


### PR DESCRIPTION
Haven't written tests for this as of opening the PR, but using the y component appears to be incorrect here.