### PR TITLE
Clean up bounding volume classes and docs

### DIFF
--- a/modules/culling/docs/api-reference/axis-aligned-bounding-box.md
+++ b/modules/culling/docs/api-reference/axis-aligned-bounding-box.md
@@ -1,0 +1,106 @@
+# AxisAlignedBoundingBox
+
+An `AxisAlignedBoundingBox` is a closed and convex cuboid that is aligned with the orthogonal axes.
+
+# Usage
+
+`AxisAlignedBoundingBox` can be created using two corners of the box:
+
+```js
+import {AxisAlignedBoundingBox} from '@math.gl/culling';
+
+const box = new AxisAlignedBoundingBox([-1, -1, -1], [1, 1, 1]);
+```
+
+Or from a collection of points:
+
+```js
+import {makeAxisAlignedBoundingBoxFromPoints} from '@math.gl/culling';
+
+const box = makeAxisAlignedBoundingBoxFromPoints([[2, 0, 0], [-2, 0, 0]]);
+```
+
+## Global Functions
+
+### makeAxisAlignedBoundingBoxFromPoints(positions : Array[3][], result? : AxisAlignedBoundingBox) : AxisAlignedBoundingBox
+
+Computes an instance of an `AxisAlignedBoundingBox` of the given positions.
+
+- `positions` List of `Vector3` points that the bounding box will enclose.
+- `result` Optional object onto which to store the result.
+
+
+## Fields
+
+### center: Vector3 = [0, 0, 0]
+
+The center position of the box.
+
+### halfDiagonal: Vector3
+
+The positive diagonal vector.
+
+### minimum: Vector3
+
+The minimum corner of the bounding box.
+
+### maximum: Vector3
+
+The maximum corner of the bounding box.
+
+
+## Methods
+
+### constructor(minimum = [0, 0, 0], maximum = [0, 0, 0]) {
+
+### constructor
+
+- {Vector3} [minimum=Vector3.ZERO] The minimum corner of the box, i.e. `[xMin, yMin, zMin]`.
+- {Vector3} [maximum=Vector3.ZERO] The maximum corner of the box, i.e. `[xMax, yMax, zMax]`.
+
+### clone() : AxisAlignedBoundingBox
+
+Duplicates a `AxisAlignedBoundingBox` instance.
+
+Returns
+- A new `AxisAlignedBoundingBox` instance.
+
+### equals(right : AxisAlignedBoundingBox) : Boolean
+
+Compares the provided `AxisAlignedBoundingBox` componentwise and returns `true` if they are equal, `false` otherwise.
+
+- `right` The second `AxisAlignedBoundingBox`
+
+Returns
+- `true` if left and right are equal, `false` otherwise.
+
+### intersectPlane(plane : Plane) : INTERSECTION
+
+Determines which side of a plane the axis-aligned bounding box is located.
+
+- `plane` The plane to test against.
+
+Returns
+- `INTERSECTION.INSIDE` if the entire box is on the side of the plane the normal is pointing
+- `INTERSECTION.OUTSIDE` if the entire box is on the opposite side, and
+- `INTERSECTION.INTERSECTING` if the box intersects the plane.
+
+### distanceTo(point : Number[3]) : Number
+
+Computes the estimated distance from the closest point on a bounding box to a point.
+
+- `point` The point
+
+Returns
+
+- The estimated distance from the bounding sphere to the point.
+
+### distanceSquaredTo(point : Number[3]) : Number
+
+Computes the estimated distance squared from the closest point on a bounding box to a point.
+
+- `point` The point
+
+Returns
+
+- The estimated distance squared from the bounding sphere to the point.

--- a/modules/culling/docs/api-reference/oriented-bounding-box.md
+++ b/modules/culling/docs/api-reference/oriented-bounding-box.md
@@ -1,10 +1,10 @@
 # OrientedBoundingBox
 
-An OrientedBoundingBox is a closed and convex cuboid. It can provide a tighter bounding volume than a bounding sphere or an axis aligned bounding box in many cases.
+An `OrientedBoundingBox` is a closed and convex cuboid. It can provide a tighter bounding volume than a bounding sphere or an axis aligned bounding box in many cases.
 
 # Usage
 
-Create an OrientedBoundingBox using a transformation matrix, a position where the box will be translated, and a scale.
+Create an `OrientedBoundingBox` using a transformation matrix, a position where the box will be translated, and a scale.
 
 ```js
 import {Vector3} from '@math.gl/core';
@@ -27,44 +27,24 @@ boxes.sort(
 Compute an oriented bounding box enclosing two points.
 
 ```js
-// import {makeBoundingBoxFromPoints} from '@math.gl/culling';
-const box = makeBoundingBoxFromPoints([[2, 0, 0], [-2, 0, 0]]);
+import {makeOrientedBoundingBoxFromPoints} from '@math.gl/culling';
+
+const box = makeOrientedBoundingBoxFromPoints([[2, 0, 0], [-2, 0, 0]]);
 ```
 
 ## Global Functions
 
-### makeBoundingBoxFromPoints(positions : Array[3][]) : OrientedBoundingBox
+### makeOrientedBoundingBoxFromPoints(positions : Array[3][], result? : OrientedBoundingBox) : OrientedBoundingBox
 
-Computes an instance of an OrientedBoundingBox of the given positions.
+Computes an instance of an `OrientedBoundingBox` of the given positions.
 This is an implementation of Stefan Gottschalk's [Collision Queries using Oriented Bounding Boxes](http://gamma.cs.unc.edu/users/gottschalk/main.pdf) (PHD thesis).
 
 - `positions` List of `Vector3` points that the bounding box will enclose.
-
-### makeBoundingBoxfromRectangle(rectangle : Rectangle [, minimumHeight : Number, maximumHeight : Number, ellipsoid : Ellipsoid]) : OrientedBoundingBox
-
-Computes an `OrientedBoundingBox` that bounds a `Rectangle` on the surface of an `Ellipsoid`.
-
-There are no guarantees about the orientation of the bounding box.
-
-- `rectangle` The cartographic rectangle on the surface of the ellipsoid.
-- `minimumHeight`=`0.0` The minimum height (elevation) within the tile.
-- `maximumHeight`=`0.0` The maximum height (elevation) within the tile.
-- `ellipsoid`=`Ellipsoid.WGS84` The ellipsoid on which the rectangle is defined.
-- `result` The object onto which to store the result.
-
-Returns
-
-- The modified result parameter or a new `OrientedBoundingBox` instance if none was provided.
-
-Throws
-
-- `rectangle.width` must be between 0 and pi.
-- `rectangle.height` must be between 0 and pi.
-- `ellipsoid` must be an ellipsoid of revolution (`radii.x == radii.y`)
+- `result` Optional object onto which to store the result.
 
 ## Fields
 
-### center: Vector3 = [0, 0, 0]
+### center: Vector3
 
 The center position of the box.
 
@@ -78,32 +58,30 @@ The transformation matrix, to rotate the box to the right position.
 
 ### constructor
 
-- {Vector3} [center=Vector3.ZERO] The center of the box.
-- {Matrix3} [halfAxes=Matrix3.ZERO] The three orthogonal half-axes of the bounding box. Equivalently, the transformation matrix, to rotate and scale a cube centered at the origin.
+- `center`=`Vector3.ZERO` The center of the box.
+- `halfAxes`=`Matrix3.ZERO` The three orthogonal half-axes of the bounding box. Equivalently, the transformation matrix, to rotate and scale a cube centered at the origin.
 
 ### clone() : OrientedBoundingBox
 
 Duplicates a OrientedBoundingBox instance.
 
-- `box` The bounding box to duplicate.
-- `result` The object onto which to store the result.
-  @returns {OrientedBoundingBox} A new OrientedBoundingBox instance.
+Returns
+- A new `OrientedBoundingBox` instance.
 
-### equals(left, right) : Boolean
+### equals(right: OrientedBoundingBox) : Boolean
 
 Compares the provided OrientedBoundingBox componentwise and returns `true` if they are equal, `false` otherwise.
 
-- left The first
-- right The second
+- `right` The second `OrientedBoundingBox`
 
-returns `true` if left and right are equal, `false` otherwise.
+Returns
+- `true` if left and right are equal, `false` otherwise.
 
 ### intersectPlane(plane : Plane) : INTERSECTION
 
 Determines which side of a plane the oriented bounding box is located.
 
-- `box` The oriented bounding box to test.
-- {Plane} plane The plane to test against.
+- `plane` The plane to test against.
 
 Returns
 - `INTERSECTION.INSIDE` if the entire box is on the side of the plane the normal is pointing
@@ -128,7 +106,7 @@ Computes the estimated distance squared from the closest point on a bounding box
 
 Returns
 
-- {Number} The estimated distance squared from the bounding sphere to the point.
+- The estimated distance squared from the bounding sphere to the point.
 
 ### computePlaneDistances(position : Number[3], direction : Number[3] [, result : Number[2]]) : Number[2]
 
@@ -144,23 +122,6 @@ Returns
 
 - The nearest and farthest distances on the bounding box from position in direction.
 
-### intersectPlane(plane : Plane) : INTERSECTION
-
-Determines which side of a plane the oriented bounding box is located.
-
-- `plane` The plane to test against.
-
-Returns
-
-- `INTERSECTION.INSIDE` if the entire box is on the side of the plane the normal is pointing
-- `INTERSECTION.OUTSIDE` if the entire box is on the opposite side, and
-- `INTERSECTION.INTERSECTING` if the box intersects the plane.
-
-### getModelMatrix() : Matrix4
-
-```js
-const modelMatrix = Matrix4.fromRotationTranslation(this.boundingVolume.halfAxes, this.boundingVolume.center);
-```
 
 ## Attribution
 

--- a/modules/culling/src/algorithms/bounding-box-from-points.d.ts
+++ b/modules/culling/src/algorithms/bounding-box-from-points.d.ts
@@ -1,4 +1,5 @@
 import OrientedBoundingBox from '../lib/oriented-bounding-box';
+import AxisAlignedBoundingBox from '../lib/axis-aligned-bounding-box';
 
 /**
  * Computes an instance of an OrientedBoundingBox of the given positions.
@@ -6,7 +7,16 @@ import OrientedBoundingBox from '../lib/oriented-bounding-box';
  * This is an implementation of Stefan Gottschalk's Collision Queries using Oriented Bounding Boxes solution (PHD thesis).
  * Reference: http://gamma.cs.unc.edu/users/gottschalk/main.pdf
  */
-export default function makeOrientedBoundingBoxfromPoints(
+export function makeOrientedBoundingBoxFromPoints(
   positions: number[][],
-  result
+  result?: OrientedBoundingBox
 ): OrientedBoundingBox;
+
+/**
+ * Computes an instance of an AxisAlignedBoundingBox. The box is determined by
+ * finding the points spaced the farthest apart on the x, y, and z axes.
+ */
+export function makeAxisAlignedBoundingBoxFromPoints(
+  positions: readonly number[][],
+  result?: AxisAlignedBoundingBox
+): AxisAlignedBoundingBox;

--- a/modules/culling/src/algorithms/bounding-box-from-points.js
+++ b/modules/culling/src/algorithms/bounding-box-from-points.js
@@ -3,6 +3,8 @@
 
 import {Vector3, Matrix3} from '@math.gl/core';
 import computeEigenDecomposition from './compute-eigen-decomposition';
+import OrientedBoundingBox from '../lib/oriented-bounding-box';
+import AxisAlignedBoundingBox from '../lib/axis-aligned-bounding-box';
 
 const scratchVector2 = new Vector3();
 
@@ -21,8 +23,8 @@ const scratchEigenResult = {
   unitary: new Matrix3()
 };
 
-// eslint-disable-next-line max-statements
-export default function makeOrientedBoundingBoxfromPoints(positions, result) {
+/* eslint-disable max-statements */
+export function makeOrientedBoundingBoxFromPoints(positions, result = new OrientedBoundingBox()) {
   if (!positions || positions.length === 0) {
     result.halfAxes = new Matrix3([0, 0, 0, 0, 0, 0, 0, 0, 0]);
     result.center = new Vector3();
@@ -107,6 +109,50 @@ export default function makeOrientedBoundingBoxfromPoints(positions, result) {
 
   const scale = scratchVector3.set(u1 - l1, u2 - l2, u3 - l3).multiplyByScalar(0.5);
   result.halfAxes.multiplyByScalar(scale);
+
+  return result;
+}
+
+export function makeAxisAlignedBoundingBoxFromPoints(
+  positions,
+  result = new AxisAlignedBoundingBox()
+) {
+  if (!positions || positions.length === 0) {
+    result.minimum.set(0, 0, 0);
+    result.maximum.set(0, 0, 0);
+    result.center.set(0, 0, 0);
+    result.halfDiagonal.set(0, 0, 0);
+    return result;
+  }
+
+  let minimumX = positions[0][0];
+  let minimumY = positions[0][1];
+  let minimumZ = positions[0][2];
+
+  let maximumX = positions[0][0];
+  let maximumY = positions[0][1];
+  let maximumZ = positions[0][2];
+
+  for (const p of positions) {
+    const x = p[0];
+    const y = p[1];
+    const z = p[2];
+
+    minimumX = Math.min(x, minimumX);
+    maximumX = Math.max(x, maximumX);
+    minimumY = Math.min(y, minimumY);
+    maximumY = Math.max(y, maximumY);
+    minimumZ = Math.min(z, minimumZ);
+    maximumZ = Math.max(z, maximumZ);
+  }
+
+  result.minimum.set(minimumX, minimumY, minimumZ);
+  result.maximum.set(maximumX, maximumY, maximumZ);
+  result.center
+    .copy(result.minimum)
+    .add(result.maximum)
+    .scale(0.5);
+  result.halfDiagonal.copy(result.maximum).subtract(result.center);
 
   return result;
 }

--- a/modules/culling/src/index.d.ts
+++ b/modules/culling/src/index.d.ts
@@ -4,8 +4,11 @@ export {default as CullingVolume} from './lib/culling-volume';
 export {default as OrientedBoundingBox} from './lib/oriented-bounding-box';
 export {default as Plane} from './lib/plane';
 
-export {default as makeOrientedBoundingBoxfromPoints} from './algorithms/bounding-box-from-points';
 export {default as makeBoundingSphereFromPoints} from './algorithms/bounding-sphere-from-points';
+export {
+  makeAxisAlignedBoundingBoxFromPoints,
+  makeOrientedBoundingBoxFromPoints
+} from './algorithms/bounding-box-from-points';
 export {default as computeEigenDecomposition} from './algorithms/compute-eigen-decomposition';
 
 // Experimental, decide how to handle enums in typescript

--- a/modules/culling/src/index.js
+++ b/modules/culling/src/index.js
@@ -13,7 +13,10 @@ export {default as _PerspectiveOffCenterFrustum} from './lib/perspective-off-cen
 export {default as _PerspectiveFrustum} from './lib/perspective-frustum';
 
 export {default as makeBoundingSphereFromPoints} from './algorithms/bounding-sphere-from-points';
-export {default as makeOrientedBoundingBoxFromPoints} from './algorithms/bounding-box-from-points';
+export {
+  makeAxisAlignedBoundingBoxFromPoints,
+  makeOrientedBoundingBoxFromPoints
+} from './algorithms/bounding-box-from-points';
 export {default as computeEigenDecomposition} from './algorithms/compute-eigen-decomposition';
 
 // Deprecated

--- a/modules/culling/src/lib/axis-aligned-bounding-box.d.ts
+++ b/modules/culling/src/lib/axis-aligned-bounding-box.d.ts
@@ -10,6 +10,7 @@ export default class AxisAlignedBoundingBox {
   readonly minimum: Vector3;
   readonly maximum: Vector3;
   readonly center: Vector3;
+  readonly halfDiagonal: Vector3;
 
   /**
    * Creates an instance of an AxisAlignedBoundingBox from the minimum and maximum points along the x, y, and z axes.
@@ -19,14 +20,15 @@ export default class AxisAlignedBoundingBox {
    */
   constructor(minimum?: readonly number[], maximum?: readonly number[], center?: readonly number[]);
 
-  /** Computes an instance of an AxisAlignedBoundingBox. The box is determined by
-   * finding the points spaced the farthest apart on the x, y, and z axes.
-   */
-  fromPoints(positions: readonly number[][]): AxisAlignedBoundingBox;
   /** Duplicates a AxisAlignedBoundingBox instance. */
   clone(): AxisAlignedBoundingBox;
   /** Compares the provided AxisAlignedBoundingBox componentwise */
   equals(right: AxisAlignedBoundingBox): boolean;
   /** Determines which side of a plane a box is located. */
   intersectPlane(plane: Plane): INTERSECTION_ENUM;
+
+  // Computes the estimated distance from the closest point on a bounding box to a point.
+  distanceTo(point: readonly number[]): number;
+  // Computes the estimated distance squared from the closest point on a bounding box to a point.
+  distanceSquaredTo(point: readonly number[]): number;
 }

--- a/modules/culling/src/lib/oriented-bounding-box.d.ts
+++ b/modules/culling/src/lib/oriented-bounding-box.d.ts
@@ -20,8 +20,6 @@ export default class OrientedBoundingBox {
   // Duplicates a OrientedBoundingBox instance.
   clone(): OrientedBoundingBox;
 
-  fromPoints(points: readonly number[][]): OrientedBoundingBox;
-
   // Compares the provided OrientedBoundingBox componentwise and returns
   equals(right: OrientedBoundingBox): boolean;
 

--- a/modules/culling/src/lib/oriented-bounding-box.js
+++ b/modules/culling/src/lib/oriented-bounding-box.js
@@ -4,14 +4,12 @@
 import {Vector3, Matrix3} from '@math.gl/core';
 import BoundingSphere from './bounding-sphere';
 import {INTERSECTION} from '../constants';
-import makeOrientedBoundingBoxfromPoints from '../algorithms/bounding-box-from-points';
 
 const scratchVector = new Vector3();
 const scratchOffset = new Vector3();
 const scratchVectorU = new Vector3();
 const scratchVectorV = new Vector3();
 const scratchVectorW = new Vector3();
-const scratchPPrime = new Vector3();
 const scratchCorner = new Vector3();
 const scratchToCenter = new Vector3();
 
@@ -40,10 +38,6 @@ export default class OrientedBoundingBox {
   // Duplicates a OrientedBoundingBox instance.
   clone() {
     return new OrientedBoundingBox(this.center, this.halfAxes);
-  }
-
-  fromPoints(points, result = new OrientedBoundingBox()) {
-    return makeOrientedBoundingBoxfromPoints(points, result);
   }
 
   // Compares the provided OrientedBoundingBox componentwise and returns
@@ -145,35 +139,21 @@ export default class OrientedBoundingBox {
     v.normalize();
     w.normalize();
 
-    const pPrime = scratchPPrime;
-    pPrime.x = offset.dot(u);
-    pPrime.y = offset.dot(v);
-    pPrime.z = offset.dot(w);
-
     let distanceSquared = 0.0;
     let d;
 
-    if (pPrime.x < -uHalf) {
-      d = pPrime.x + uHalf;
-      distanceSquared += d * d;
-    } else if (pPrime.x > uHalf) {
-      d = pPrime.x - uHalf;
+    d = Math.abs(offset.dot(u)) - uHalf;
+    if (d > 0) {
       distanceSquared += d * d;
     }
 
-    if (pPrime.y < -vHalf) {
-      d = pPrime.y + vHalf;
-      distanceSquared += d * d;
-    } else if (pPrime.y > vHalf) {
-      d = pPrime.y - vHalf;
+    d = Math.abs(offset.dot(v)) - vHalf;
+    if (d > 0) {
       distanceSquared += d * d;
     }
 
-    if (pPrime.z < -wHalf) {
-      d = pPrime.z + wHalf;
-      distanceSquared += d * d;
-    } else if (pPrime.z > wHalf) {
-      d = pPrime.z - wHalf;
+    d = Math.abs(offset.dot(w)) - wHalf;
+    if (d > 0) {
       distanceSquared += d * d;
     }
 

--- a/modules/culling/test/lib/axis-aligned-bounding-box.spec.js
+++ b/modules/culling/test/lib/axis-aligned-bounding-box.spec.js
@@ -1,7 +1,12 @@
 // import test from 'tape-catch';
 import {it, expect} from 'test/utils/expect-assertions';
 
-import {AxisAlignedBoundingBox, INTERSECTION, Plane} from '@math.gl/culling';
+import {
+  AxisAlignedBoundingBox,
+  makeAxisAlignedBoundingBoxFromPoints,
+  INTERSECTION,
+  Plane
+} from '@math.gl/culling';
 import {Vector3} from '@math.gl/core';
 
 const positions = [
@@ -50,22 +55,22 @@ it('AxisAlignedBoundingBox#constructor computes center if not supplied', () => {
   expect(box.center).toEqual(expectedCenter);
 });
 
-it('AxisAlignedBoundingBox#fromPoints constructs empty box with undefined positions', () => {
-  const box = new AxisAlignedBoundingBox().fromPoints(undefined);
+it('makeAxisAlignedBoundingBoxFromPoints constructs empty box with undefined positions', () => {
+  const box = makeAxisAlignedBoundingBoxFromPoints(undefined);
   expect(box.minimum).toEqual(VECTOR3_ZERO);
   expect(box.maximum).toEqual(VECTOR3_ZERO);
   expect(box.center).toEqual(VECTOR3_ZERO);
 });
 
-it('AxisAlignedBoundingBox#fromPoints constructs empty box with empty positions', () => {
-  const box = new AxisAlignedBoundingBox().fromPoints([]);
+it('makeAxisAlignedBoundingBoxFromPoints constructs empty box with empty positions', () => {
+  const box = makeAxisAlignedBoundingBoxFromPoints([]);
   expect(box.minimum).toEqual(VECTOR3_ZERO);
   expect(box.maximum).toEqual(VECTOR3_ZERO);
   expect(box.center).toEqual(VECTOR3_ZERO);
 });
 
-it('AxisAlignedBoundingBox#fromPoints computes the correct values', () => {
-  const box = new AxisAlignedBoundingBox().fromPoints(positions);
+it('makeAxisAlignedBoundingBoxFromPoints computes the correct values', () => {
+  const box = makeAxisAlignedBoundingBoxFromPoints(positions);
   expect(box.minimum).toEqual(positionsMinimum);
   expect(box.maximum).toEqual(positionsMaximum);
   expect(box.center).toEqual(positionsCenter);
@@ -86,25 +91,17 @@ it('AxisAlignedBoundingBox#clone with box of offset center', () => {
 });
 
 it('AxisAlignedBoundingBox#equals works in all cases', () => {
-  const box = new AxisAlignedBoundingBox(VECTOR3_UNIT_X, VECTOR3_UNIT_Y, VECTOR3_UNIT_Z);
+  const box = new AxisAlignedBoundingBox(VECTOR3_UNIT_X, VECTOR3_UNIT_Y);
   const bogie = new Vector3(2, 3, 4);
-  expect(
-    box.equals(new AxisAlignedBoundingBox(VECTOR3_UNIT_X, VECTOR3_UNIT_Y, VECTOR3_UNIT_Z))
-  ).toEqual(true);
-  expect(box.equals(new AxisAlignedBoundingBox(bogie, VECTOR3_UNIT_Y, VECTOR3_UNIT_Y))).toEqual(
-    false
-  );
-  expect(box.equals(new AxisAlignedBoundingBox(VECTOR3_UNIT_X, bogie, VECTOR3_UNIT_Z))).toEqual(
-    false
-  );
-  expect(box.equals(new AxisAlignedBoundingBox(VECTOR3_UNIT_X, VECTOR3_UNIT_Y, bogie))).toEqual(
-    false
-  );
+  expect(box.equals(new AxisAlignedBoundingBox(VECTOR3_UNIT_X, VECTOR3_UNIT_Y))).toEqual(true);
+  expect(box.equals(new AxisAlignedBoundingBox(bogie, VECTOR3_UNIT_Y))).toEqual(false);
+  expect(box.equals(new AxisAlignedBoundingBox(VECTOR3_UNIT_X, bogie))).toEqual(false);
+  expect(box.equals(new AxisAlignedBoundingBox(VECTOR3_UNIT_X, VECTOR3_UNIT_Y))).toEqual(true);
   expect(box.equals(undefined)).toEqual(false);
 });
 
-it('AxisAlignedBoundingBox#computes the bounding box for a single position', () => {
-  const box = new AxisAlignedBoundingBox().fromPoints([positions[0]]);
+it('makeAxisAlignedBoundingBoxFromPoints computes the bounding box for a single position', () => {
+  const box = makeAxisAlignedBoundingBoxFromPoints([positions[0]]);
   expect(box.minimum).toEqual(positions[0]);
   expect(box.maximum).toEqual(positions[0]);
   expect(box.center).toEqual(positions[0]);
@@ -143,4 +140,15 @@ it('AxisAlignedBoundingBox#intersectPlane throws without a plane', () => {
   expect(() => {
     box.intersectPlane(undefined);
   }).toThrow();
+});
+
+it('AxisAlignedBoundingBox#distanceTo', () => {
+  const minimum = new Vector3(1, 2, 3);
+  const maximum = new Vector3(4, 5, 6);
+  const center = new Vector3(2.5, 3.5, 4.5);
+  const box = new AxisAlignedBoundingBox(minimum, maximum, center);
+
+  expect(box.distanceTo([2.5, 3.5, 4.5])).toEqual(0);
+  expect(box.distanceTo([1, 2, 3])).toEqual(0);
+  expect(box.distanceTo([0, 0, 0])).toEqual(Math.sqrt(14));
 });

--- a/modules/culling/test/lib/culling-volume.spec.js
+++ b/modules/culling/test/lib/culling-volume.spec.js
@@ -10,6 +10,7 @@ import {
   BoundingSphere,
   AxisAlignedBoundingBox,
   makeBoundingSphereFromPoints,
+  makeAxisAlignedBoundingBoxFromPoints,
   _PerspectiveFrustum as PerspectiveFrustum,
   INTERSECTION
 } from '@math.gl/culling';
@@ -84,7 +85,7 @@ function testWithAndWithoutPlaneMask(t, culling, bound, intersect) {
 
 test('CullingVolume#box intersections', ttt => {
   ttt.test('CullingVolume#can contain an axis aligned bounding box', t => {
-    const box1 = new AxisAlignedBoundingBox().fromPoints([
+    const box1 = makeAxisAlignedBoundingBoxFromPoints([
       new Vector3(-0.5, 0, -1.25),
       new Vector3(0.5, 0, -1.25),
       new Vector3(-0.5, 0, -1.75),
@@ -96,7 +97,7 @@ test('CullingVolume#box intersections', ttt => {
 
   ttt.test('CullingVolume#can partially contain an axis aligned bounding box', tt => {
     tt.test('CullingVolume#on the far plane', t => {
-      const box2 = new AxisAlignedBoundingBox().fromPoints([
+      const box2 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(-0.5, 0, -1.5),
         new Vector3(0.5, 0, -1.5),
         new Vector3(-0.5, 0, -2.5),
@@ -107,7 +108,7 @@ test('CullingVolume#box intersections', ttt => {
     });
 
     tt.test('CullingVolume#on the near plane', t => {
-      const box3 = new AxisAlignedBoundingBox().fromPoints([
+      const box3 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(-0.5, 0, -0.5),
         new Vector3(0.5, 0, -0.5),
         new Vector3(-0.5, 0, -1.5),
@@ -118,7 +119,7 @@ test('CullingVolume#box intersections', ttt => {
     });
 
     tt.test('CullingVolume#on the left plane', t => {
-      const box4 = new AxisAlignedBoundingBox().fromPoints([
+      const box4 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(-1.5, 0, -1.25),
         new Vector3(0, 0, -1.25),
         new Vector3(-1.5, 0, -1.5),
@@ -129,7 +130,7 @@ test('CullingVolume#box intersections', ttt => {
     });
 
     tt.test('CullingVolume#on the right plane', t => {
-      const box5 = new AxisAlignedBoundingBox().fromPoints([
+      const box5 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(0, 0, -1.25),
         new Vector3(1.5, 0, -1.25),
         new Vector3(0, 0, -1.5),
@@ -140,7 +141,7 @@ test('CullingVolume#box intersections', ttt => {
     });
 
     tt.test('CullingVolume#on the top plane', t => {
-      const box6 = new AxisAlignedBoundingBox().fromPoints([
+      const box6 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(-0.5, 0, -1.25),
         new Vector3(0.5, 0, -1.25),
         new Vector3(-0.5, 2.0, -1.75),
@@ -151,7 +152,7 @@ test('CullingVolume#box intersections', ttt => {
     });
 
     tt.test('CullingVolume#on the bottom plane', t => {
-      const box7 = new AxisAlignedBoundingBox().fromPoints([
+      const box7 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(-0.5, -2.0, -1.25),
         new Vector3(0.5, 0, -1.25),
         new Vector3(-0.5, -2.0, -1.5),
@@ -165,7 +166,7 @@ test('CullingVolume#box intersections', ttt => {
 
   test('CullingVolume#can not contain an axis aligned bounding box', tt => {
     test('CullingVolume#past the far plane', t => {
-      const box8 = new AxisAlignedBoundingBox().fromPoints([
+      const box8 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(-0.5, 0, -2.25),
         new Vector3(0.5, 0, -2.25),
         new Vector3(-0.5, 0, -2.75),
@@ -176,7 +177,7 @@ test('CullingVolume#box intersections', ttt => {
     });
 
     test('CullingVolume#before the near plane', t => {
-      const box9 = new AxisAlignedBoundingBox().fromPoints([
+      const box9 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(-0.5, 0, -0.25),
         new Vector3(0.5, 0, -0.25),
         new Vector3(-0.5, 0, -0.75),
@@ -187,7 +188,7 @@ test('CullingVolume#box intersections', ttt => {
     });
 
     test('CullingVolume#past the left plane', t => {
-      const box10 = new AxisAlignedBoundingBox().fromPoints([
+      const box10 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(-5, 0, -1.25),
         new Vector3(-3, 0, -1.25),
         new Vector3(-5, 0, -1.75),
@@ -198,7 +199,7 @@ test('CullingVolume#box intersections', ttt => {
     });
 
     test('CullingVolume#past the right plane', t => {
-      const box11 = new AxisAlignedBoundingBox().fromPoints([
+      const box11 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(3, 0, -1.25),
         new Vector3(5, 0, -1.25),
         new Vector3(3, 0, -1.75),
@@ -209,7 +210,7 @@ test('CullingVolume#box intersections', ttt => {
     });
 
     test('CullingVolume#past the top plane', t => {
-      const box12 = new AxisAlignedBoundingBox().fromPoints([
+      const box12 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(-0.5, 3, -1.25),
         new Vector3(0.5, 3, -1.25),
         new Vector3(-0.5, 5, -1.75),
@@ -220,7 +221,7 @@ test('CullingVolume#box intersections', ttt => {
     });
 
     test('CullingVolume#past the bottom plane', t => {
-      const box13 = new AxisAlignedBoundingBox().fromPoints([
+      const box13 = makeAxisAlignedBoundingBoxFromPoints([
         new Vector3(-0.5, -3, -1.25),
         new Vector3(0.5, -3, -1.25),
         new Vector3(-0.5, -5, -1.75),

--- a/modules/culling/test/lib/oriented-bounding-box.spec.js
+++ b/modules/culling/test/lib/oriented-bounding-box.spec.js
@@ -6,7 +6,13 @@ import test from 'tape-catch';
 import {tapeEquals, tapeEqualsEpsilon} from 'test/utils/tape-assertions';
 
 import {Vector3, Matrix3, toRadians, _MathUtils} from '@math.gl/core';
-import {BoundingSphere, OrientedBoundingBox, Plane, INTERSECTION} from '@math.gl/culling';
+import {
+  BoundingSphere,
+  OrientedBoundingBox,
+  makeOrientedBoundingBoxFromPoints,
+  Plane,
+  INTERSECTION
+} from '@math.gl/culling';
 
 const ZERO_VECTOR3 = Object.freeze(new Vector3(0, 0, 0));
 const ZERO_MATRIX3 = Object.freeze(new Matrix3([0, 0, 0, 0, 0, 0, 0, 0, 0]));
@@ -84,7 +90,7 @@ test('OrientedBoundingBox#equals works in all cases', t => {
 });
 
 test('OrientedBoundingBox#getBoundingSphere works with a result', t => {
-  const box = new OrientedBoundingBox().fromPoints(spherePositions);
+  const box = makeOrientedBoundingBoxFromPoints(spherePositions);
   const sphere = new BoundingSphere();
   box.getBoundingSphere(sphere);
   tapeEquals(t, sphere.center, positionsCenter);
@@ -94,7 +100,7 @@ test('OrientedBoundingBox#getBoundingSphere works with a result', t => {
 });
 
 test('OrientedBoundingBox#getBoundingSphere works without a result parameter', t => {
-  const box = new OrientedBoundingBox().fromPoints(spherePositions);
+  const box = makeOrientedBoundingBoxFromPoints(spherePositions);
   const sphere = box.getBoundingSphere();
   tapeEquals(t, sphere.center, positionsCenter);
   t.ok(sphere.radius > 1.5);


### PR DESCRIPTION
- Add `distanceTo` and `distanceToSquare` methods to `AxisAlignedBoundingBox`
- Remove `AxisAlignedBoundingBox.fromPoints` (not documented, not used), add `makeAxisAlignedBoundingBoxFromPoints`
- Remove `OrientedBoundingBox.fromPoints` (not documented, not used)
- Fix errors in the documentation of `OrientedBoundingBox`
- Add documentation for `AxisAlignedBoundingBox`