### PR TITLE
Fix the bounds type for FitBoundsOptions

### DIFF
--- a/modules/web-mercator/src/fit-bounds.d.ts
+++ b/modules/web-mercator/src/fit-bounds.d.ts
@@ -29,7 +29,7 @@ type Padding = {
 type FitBoundsOptions = {
   width: number;
   height: number;
-  bounds: number;
+  bounds: [[number, number], [number, number]];
   minExtent?: number; // 0.01 would be about 1000 meters (degree is ~110KM)
   maxZoom?: number; // ~x4,000,000 => About 10 meter extents
   // options

--- a/modules/web-mercator/src/fit-bounds.d.ts
+++ b/modules/web-mercator/src/fit-bounds.d.ts
@@ -6,7 +6,7 @@
  * @property left - Padding from left in pixels to add to the given bounds
  * @property right - Padding from right in pixels to add to the given bounds
  */
-type Padding = {
+export type Padding = {
   top: number;
   bottom: number;
   left: number;
@@ -26,7 +26,7 @@ type Padding = {
  *  properties defining the padding.
  * @param [options.offset] - The center of the given bounds relative to the map's center,
  */
-type FitBoundsOptions = {
+export type FitBoundsOptions = {
   width: number;
   height: number;
   bounds: [[number, number], [number, number]];
@@ -37,7 +37,7 @@ type FitBoundsOptions = {
   offset?: number[];
 };
 
-type Bounds = {
+export type Bounds = {
   longitude: number;
   latitude: number;
   zoom: number;

--- a/modules/web-mercator/src/web-mercator-viewport.d.ts
+++ b/modules/web-mercator/src/web-mercator-viewport.d.ts
@@ -1,3 +1,5 @@
+import { Bounds, FitBoundsOptions } from "./fit-bounds";
+
 type WebMercatorViewportOptions = {
   // Map state
   width: number;
@@ -141,7 +143,7 @@ export default class WebMercatorViewport {
    *   Specifies a point on the screen.
    * @return [lng,lat] new map center.
    */
-  getMapCenterByLngLatPosition({lngLat, pos}): number[];
+  getMapCenterByLngLatPosition({lngLat, pos}: {lngLat: number[], pos: number[]}): number[];
 
   /** @deprecated Legacy method name */
   getLocationAtPoint({lngLat, pos}): number[];
@@ -156,5 +158,8 @@ export default class WebMercatorViewport {
    *    [x, y] measured in pixels.
    * @returns {WebMercatorViewport}
    */
-  fitBounds(bounds, options?: {padding?: number; offset?: [number, number]}): WebMercatorViewport;
+  fitBounds(
+    bounds: [[number, number], [number, number]],
+    options?: Omit<FitBoundsOptions, 'width' | 'height' | 'bounds'>,
+  ): WebMercatorViewport;
 }

--- a/modules/web-mercator/test/spec/fit-bounds.spec.js
+++ b/modules/web-mercator/test/spec/fit-bounds.spec.js
@@ -3,7 +3,7 @@ import {fitBounds} from '@math.gl/web-mercator';
 import {WebMercatorViewport} from '@math.gl/web-mercator';
 import {toLowPrecision} from '../utils/test-utils';
 
-const FITBOUNDS_TEST_CASES = [
+const FITBOUNDS_TEST_CASES = /** @type {[import('@math.gl/web-mercator/fit-bounds').FitBoundsOptions, import('@math.gl/web-mercator/fit-bounds').Bounds][]} */ ([
   [
     {
       width: 100,
@@ -84,11 +84,10 @@ const FITBOUNDS_TEST_CASES = [
       zoom: 12.476957831
     }
   ]
-];
+]);
 
 test('fitBounds', t => {
   for (const [input, expected] of FITBOUNDS_TEST_CASES) {
-    // @ts-ignore
     const result = fitBounds(input);
 
     t.ok(Number.isFinite(result.longitude), 'get valid longitude');
@@ -108,7 +107,6 @@ test('WebMercatorViewport.fitBounds', t => {
       height: input.height,
       zoom: 11
     });
-    // @ts-ignore
     const result = viewport.fitBounds(input.bounds, input);
 
     t.ok(result instanceof WebMercatorViewport, 'get viewport');
@@ -142,12 +140,10 @@ test('fitBounds#degenerate', t => {
     'degenerate bounds do not throw by default'
   );
   t.throws(
-    // @ts-ignore
     () => viewport.fitBounds([[-70, 10], [-70, 10]], {maxZoom: Infinity}),
     'degenerate bounds throw if maxZoom removed'
   );
   t.doesNotThrow(
-    // @ts-ignore
     () => viewport.fitBounds([[-70, 10], [-70, 10]], {minExtent: 0.01, maxZoom: Infinity}),
     'degenerate bounds does not throw if maxZoom removed and minExtents added'
   );


### PR DESCRIPTION
It's expected to be a pair of pairs (`[[lon, lat], [lon, lat]]`), but the type is declared as `number`.