### PR TITLE
cutPolygonByGrid: add option to generate edge type flags

### DIFF
--- a/modules/polygon/docs/api-reference/cut-polygon-by-grid.md
+++ b/modules/polygon/docs/api-reference/cut-polygon-by-grid.md
@@ -27,9 +27,14 @@ Arguments:
   + `size` (Number) - the number of elements in each vertex. Size `2` will interpret `positions` as `[x0, y0, x1, y1, ...]` and size `3` will interpret `positions` as `[x0, y0, z0, x1, y1, z1, ...]`. Default `2`.
   + `gridResolution` (Number, optional) - the grid size. Default `10`.
   + `gridOffset` (Array, optional) - the grid offset in `[x, y]`. Default `[0, 0]` i.e. the grid starts from the coordinate origin.
+  + `vertexTypes` (Boolean) - if `true`, returns an additional array for each polygon that describes the nature of each vertex. See "returns" below.
 
 Returns:
 
-An array of polygons. Each polygons is represented by either:
-- a positions array that uses the same vertex size as the input
-- an object in the shape of `{positions, holeIndices}`
+An array of polygons. Each polygons is represented by an object with the following fields:
+- `positions` (Array) - a flat array of the vertex positions that define the polygon's rings.
+- `holeIndices` (Array) - the indices in `positions` where each hole starts. Not present if the polygon has no holes.
+- `vertexTypes` (Array) - describes the nature of each vertex in `positions`:
+  + `0` - a vertex in the original polygon
+  + `1` - an interpolated point on the edge of the original polygon
+  + `2` - a point inside the original polygon

--- a/modules/polygon/docs/api-reference/cut-polygon-by-grid.md
+++ b/modules/polygon/docs/api-reference/cut-polygon-by-grid.md
@@ -27,14 +27,14 @@ Arguments:
   + `size` (Number) - the number of elements in each vertex. Size `2` will interpret `positions` as `[x0, y0, x1, y1, ...]` and size `3` will interpret `positions` as `[x0, y0, z0, x1, y1, z1, ...]`. Default `2`.
   + `gridResolution` (Number, optional) - the grid size. Default `10`.
   + `gridOffset` (Array, optional) - the grid offset in `[x, y]`. Default `[0, 0]` i.e. the grid starts from the coordinate origin.
-  + `vertexTypes` (Boolean) - if `true`, returns an additional array for each polygon that describes the nature of each vertex. See "returns" below.
+  + `edgeTypes` (Boolean) - if `true`, returns an additional array for each polygon that describes the nature of each vertex. See "returns" below.
 
 Returns:
 
 An array of polygons. Each polygons is represented by an object with the following fields:
 - `positions` (Array) - a flat array of the vertex positions that define the polygon's rings.
 - `holeIndices` (Array) - the indices in `positions` where each hole starts. Not present if the polygon has no holes.
-- `vertexTypes` (Array) - describes the nature of each vertex in `positions`:
-  + `0` - a vertex in the original polygon
-  + `1` - an interpolated point on the edge of the original polygon
-  + `2` - a point inside the original polygon
+- `edgeTypes` (Array) - describes the nature of each vertex in `positions`:
+  + `0` - the segment connecting this vertex to the next is inside the original polygon
+  + `1` - the segment connecting this vertex to the next is on the border of the original polygon
+  

--- a/modules/polygon/docs/api-reference/cut-polygon-by-mercator-bounds.md
+++ b/modules/polygon/docs/api-reference/cut-polygon-by-mercator-bounds.md
@@ -27,9 +27,14 @@ Arguments:
   + `size` (Number) - the number of elements in each vertex. Size `2` will interpret `positions` as `[x0, y0, x1, y1, ...]` and size `3` will interpret `positions` as `[x0, y0, z0, x1, y1, z1, ...]`. Default `2`.
   + `normalize` (Boolean) - make sure the output longitudes are within `[-180, 180]`. Default `true`.
   + `maxLatitude` (Number) - since latitude=90 projects to infinity in Web Mercator projection, `maxLatitude` will be used to represent the pole. Default `85.051129` which makes the map square.
+  + `vertexTypes` (Boolean) - if `true`, returns an additional array for each polygon that describes the nature of each vertex. See "returns" below.
 
 Returns:
 
-An array of polygons. Each polygons is represented by either:
-- a positions array that uses the same vertex size as the input
-- an object in the shape of `{positions, holeIndices}`
+An array of polygons. Each polygons is represented by an object with the following fields:
+- `positions` (Array) - a flat array of the vertex positions that define the polygon's rings.
+- `holeIndices` (Array) - the indices in `positions` where each hole starts. Not present if the polygon has no holes.
+- `vertexTypes` (Array) - describes the nature of each vertex in `positions`:
+  + `0` - a vertex in the original polygon
+  + `1` - an interpolated point on the edge of the original polygon
+  + `2` - a point inside the original polygon

--- a/modules/polygon/docs/api-reference/cut-polygon-by-mercator-bounds.md
+++ b/modules/polygon/docs/api-reference/cut-polygon-by-mercator-bounds.md
@@ -27,14 +27,13 @@ Arguments:
   + `size` (Number) - the number of elements in each vertex. Size `2` will interpret `positions` as `[x0, y0, x1, y1, ...]` and size `3` will interpret `positions` as `[x0, y0, z0, x1, y1, z1, ...]`. Default `2`.
   + `normalize` (Boolean) - make sure the output longitudes are within `[-180, 180]`. Default `true`.
   + `maxLatitude` (Number) - since latitude=90 projects to infinity in Web Mercator projection, `maxLatitude` will be used to represent the pole. Default `85.051129` which makes the map square.
-  + `vertexTypes` (Boolean) - if `true`, returns an additional array for each polygon that describes the nature of each vertex. See "returns" below.
+  + `edgeTypes` (Boolean) - if `true`, returns an additional array for each polygon that describes the nature of each vertex. See "returns" below.
 
 Returns:
 
 An array of polygons. Each polygons is represented by an object with the following fields:
 - `positions` (Array) - a flat array of the vertex positions that define the polygon's rings.
 - `holeIndices` (Array) - the indices in `positions` where each hole starts. Not present if the polygon has no holes.
-- `vertexTypes` (Array) - describes the nature of each vertex in `positions`:
-  + `0` - a vertex in the original polygon
-  + `1` - an interpolated point on the edge of the original polygon
-  + `2` - a point inside the original polygon
+- `edgeTypes` (Array) - describes the nature of each vertex in `positions`:
+  + `0` - the segment connecting this vertex to the next is inside the original polygon
+  + `1` - the segment connecting this vertex to the next is on the border of the original polygon

--- a/modules/polygon/src/cut-by-grid.d.ts
+++ b/modules/polygon/src/cut-by-grid.d.ts
@@ -1,8 +1,8 @@
-type Polygon = Array<number> | {positions: Array<number>, holeIndices: Array<number>};
+type Polygon = {positions: Array<number>, holeIndices?: Array<number>, vertexTypes?: Array<Number>};
 
 export function cutPolylineByGrid(
   positions : Array<number>,
-  options : {
+  options? : {
     size? : number,
     broken? : boolean,
     gridResolution? : number,
@@ -15,9 +15,10 @@ export function cutPolylineByGrid(
 export function cutPolygonByGrid(
   positions : Array<number>,
   holeIndices : Array<number> | null,
-  options : {
+  options? : {
     size? : number,
     gridResolution? : number,
-    gridOffset? : [number, number]
+    gridOffset? : [number, number],
+    vertexTypes? : boolean
   }
 ) : Array<Polygon>;

--- a/modules/polygon/src/cut-by-grid.d.ts
+++ b/modules/polygon/src/cut-by-grid.d.ts
@@ -19,6 +19,6 @@ export function cutPolygonByGrid(
     size? : number,
     gridResolution? : number,
     gridOffset? : [number, number],
-    vertexTypes? : boolean
+    edgeTypes? : boolean
   }
 ) : Array<Polygon>;

--- a/modules/polygon/src/cut-by-mercator-bounds.d.ts
+++ b/modules/polygon/src/cut-by-mercator-bounds.d.ts
@@ -2,7 +2,7 @@ import {Polygon} from "./cut-by-grid";
 
 export function cutPolylineByMercatorBounds(
   positions : Array<number>,
-  options : {
+  options? : {
     size? : number,
     startIndex? : number,
     endIndex? : number,
@@ -13,10 +13,11 @@ export function cutPolylineByMercatorBounds(
 export function cutPolygonByMercatorBounds(
   positions : Array<number>,
   holeIndices : Array<number> | null,
-  options : {
+  options? : {
     size? : number,
     normalize? : boolean,
-    maxLatitude: number
+    maxLatitude?: number,
+    vertexTypes? : boolean
   }
 ) : Array<Polygon>;
 

--- a/modules/polygon/src/cut-by-mercator-bounds.d.ts
+++ b/modules/polygon/src/cut-by-mercator-bounds.d.ts
@@ -17,7 +17,7 @@ export function cutPolygonByMercatorBounds(
     size? : number,
     normalize? : boolean,
     maxLatitude?: number,
-    vertexTypes? : boolean
+    edgeTypes? : boolean
   }
 ) : Array<Polygon>;
 

--- a/modules/polygon/src/cut-by-mercator-bounds.js
+++ b/modules/polygon/src/cut-by-mercator-bounds.js
@@ -31,7 +31,7 @@ export function cutPolylineByMercatorBounds(positions, options = {}) {
 
 // https://user-images.githubusercontent.com/2059298/78465770-94241080-76ae-11ea-809a-6a8534dac1d9.png
 export function cutPolygonByMercatorBounds(positions, holeIndices, options = {}) {
-  const {size = 2, normalize = true, vertexTypes = false} = options;
+  const {size = 2, normalize = true, edgeTypes = false} = options;
   holeIndices = holeIndices || [];
   const newPositions = [];
   const newHoleIndices = [];
@@ -70,7 +70,7 @@ export function cutPolygonByMercatorBounds(positions, holeIndices, options = {})
     size,
     gridResolution: 360,
     gridOffset: [-180, -180],
-    vertexTypes
+    edgeTypes
   });
 
   if (normalize) {

--- a/modules/polygon/src/cut-by-mercator-bounds.js
+++ b/modules/polygon/src/cut-by-mercator-bounds.js
@@ -31,7 +31,7 @@ export function cutPolylineByMercatorBounds(positions, options = {}) {
 
 // https://user-images.githubusercontent.com/2059298/78465770-94241080-76ae-11ea-809a-6a8534dac1d9.png
 export function cutPolygonByMercatorBounds(positions, holeIndices, options = {}) {
-  const {size = 2, normalize = true} = options;
+  const {size = 2, normalize = true, vertexTypes = false} = options;
   holeIndices = holeIndices || [];
   const newPositions = [];
   const newHoleIndices = [];
@@ -69,14 +69,15 @@ export function cutPolygonByMercatorBounds(positions, holeIndices, options = {})
   const parts = cutPolygonByGrid(newPositions, newHoleIndices, {
     size,
     gridResolution: 360,
-    gridOffset: [-180, -180]
+    gridOffset: [-180, -180],
+    vertexTypes
   });
 
   if (normalize) {
     // Each part is guaranteed to be in a single copy of the world
     // Map longitudes back to [-180, 180]
     for (const part of parts) {
-      shiftLongitudesIntoRange(Array.isArray(part) ? part : part.positions, size);
+      shiftLongitudesIntoRange(part.positions, size);
     }
   }
   return parts;

--- a/modules/polygon/src/lineclip.d.ts
+++ b/modules/polygon/src/lineclip.d.ts
@@ -3,7 +3,7 @@ type BoundingBox = [number, number, number, number];
 export function clipPolyline(
   positions : Array<number>,
   bbox : BoundingBox,
-  options : {
+  options? : {
     size? : number,
     startIndex? : number,
     endIndex? : number
@@ -13,7 +13,7 @@ export function clipPolyline(
 export function clipPolygon(
   positions: Array<number>,
   bbox: BoundingBox,
-  options : {
+  options? : {
     size? : number,
     startIndex? : number,
     endIndex? : number

--- a/modules/polygon/test/cut-by-mercator-bounds.spec.js
+++ b/modules/polygon/test/cut-by-mercator-bounds.spec.js
@@ -77,27 +77,21 @@ test('cutPolygonByMercatorBounds - simple', t => {
   const expectedA = [[170, 20], [180, 20], [180, 0], [170, 0]];
   const expectedB = [[-180, 20], [-170, 20], [-170, 0], [-180, 0]];
 
-  t.ok(
-    equals(cutPolygonByMercatorBounds(flatten(polygon)), [flatten(expectedA), flatten(expectedB)]),
-    '2d'
-  );
+  let parts = cutPolygonByMercatorBounds(flatten(polygon));
+  t.ok(equals(parts[0].positions, flatten(expectedA)), '2d');
+  t.ok(equals(parts[1].positions, flatten(expectedB)), '2d');
 
   const flatten2 = (ring, accessPosition) => flatten(ring.map(accessPosition));
   const addZ = p => [p[0], p[1], 100];
 
-  t.ok(
-    equals(cutPolygonByMercatorBounds(flatten2(polygon, addZ), null, {size: 3}), [
-      flatten2(expectedA, addZ),
-      flatten2(expectedB, addZ)
-    ]),
-    '3d'
-  );
+  parts = cutPolygonByMercatorBounds(flatten2(polygon, addZ), null, {size: 3});
+  t.ok(equals(parts[0].positions, flatten2(expectedA, addZ)), '3d');
+  t.ok(equals(parts[1].positions, flatten2(expectedB, addZ)), '3d');
 
+  parts = cutPolygonByMercatorBounds(flatten(polygon), null, {normalize: false});
+  t.ok(equals(parts[0].positions, flatten(expectedA)), 'normalize: false');
   t.ok(
-    equals(cutPolygonByMercatorBounds(flatten(polygon), null, {normalize: false}), [
-      flatten(expectedA),
-      flatten2(expectedB, p => [p[0] + 360, p[1]])
-    ]),
+    equals(parts[1].positions, flatten2(expectedB, p => [p[0] + 360, p[1]])),
     'normalize: false'
   );
 
@@ -117,13 +111,13 @@ test('cutPolygonByMercatorBounds - with holes', t => {
   t.ok(
     equals(result[0].positions, flatten([expectedA, holeA])) &&
       equals(result[0].holeIndices, [8]) &&
-      equals(result[1], flatten(expectedB))
+      equals(result[1].positions, flatten(expectedB))
   );
 
   result = cutPolygonByMercatorBounds(flatten([polygon, holeB]), [8]);
   t.is(result.length, 2, 'Returns correct number of parts');
   t.ok(
-    equals(result[0], flatten(expectedA)) &&
+    equals(result[0].positions, flatten(expectedA)) &&
       equals(result[1].positions, flatten([expectedB, holeB])) &&
       equals(result[1].holeIndices, [8])
   );
@@ -135,9 +129,9 @@ test('cutPolygonByMercatorBounds - contains pole', t => {
   const polygon = [[-150, 75], [-90, 80], [-30, 70], [30, 60], [90, 70], [150, 75]];
 
   const result = cutPolygonByMercatorBounds(flatten(polygon));
-
   t.ok(
-    equals(result, [
+    equals(
+      result[0].positions,
       flatten([
         [-90, 80],
         [-30, 70],
@@ -147,9 +141,14 @@ test('cutPolygonByMercatorBounds - contains pole', t => {
         [180, 75],
         [180, 85.051129],
         [-90, 85.051129]
-      ]),
+      ])
+    )
+  );
+  t.ok(
+    equals(
+      result[1].positions,
       flatten([[-180, 75], [-150, 75], [-90, 80], [-90, 85.051129], [-180, 85.051129]])
-    ])
+    )
   );
 
   t.end();


### PR DESCRIPTION
Adds an option `edgeTypes` to `cutPolygonByGrid` and `cutPolygonByMercatorBounds`. When enabled, the returned polygons contain an array of flags for each vertex:
  + `0` - the segment connecting this vertex to the next is inside the original polygon
  + `1` - the segment connecting this vertex to the next is on the border of the original polygon


This is needed by deck.gl to determine where to draw the sides of an extruded polygon.

A visualization of this feature: https://codepen.io/Pessimistress/pen/BaNOmKM?editors=0110

![image](https://user-images.githubusercontent.com/2059298/84531278-3822cd00-ac99-11ea-97ea-1ac8ab4e9053.png)
