### PR TITLE
Fixed missing newline breaking ReactMapGL docs

### DIFF
--- a/modules/web-mercator/docs/api-reference/web-mercator-viewport.md
+++ b/modules/web-mercator/docs/api-reference/web-mercator-viewport.md
@@ -78,14 +78,14 @@ Returns:
 - `[x, y]`, representing Web Mercator coordinates.
 
 ##### `unprojectFlat(xy, scale)`
-
+<!-- prettier-ignore-start -->
 Unprojects a Web Mercator coordinate to longitude and latitude.
-<!-- prettier-ignore -->
+
 | Parameter | Type | Default | Description |
 | -------------- | --------- | -------- | ------------------------------- |
 | `xy` | `Array` | (required) | Web Mercator coordinates, `[x, y]` |
 | `scale` | `number` | `this.scale` | Web Mercator scale |
-
+<!-- prettier-ignore-end -->
 Returns:
 
 - `[longitude, latitude]`

--- a/modules/web-mercator/docs/api-reference/web-mercator-viewport.md
+++ b/modules/web-mercator/docs/api-reference/web-mercator-viewport.md
@@ -80,7 +80,7 @@ Returns:
 ##### `unprojectFlat(xy, scale)`
 
 Unprojects a Web Mercator coordinate to longitude and latitude.
-
+<!-- prettier-ignore -->
 | Parameter | Type | Default | Description |
 | -------------- | --------- | -------- | ------------------------------- |
 | `xy` | `Array` | (required) | Web Mercator coordinates, `[x, y]` |

--- a/modules/web-mercator/docs/api-reference/web-mercator-viewport.md
+++ b/modules/web-mercator/docs/api-reference/web-mercator-viewport.md
@@ -80,6 +80,7 @@ Returns:
 ##### `unprojectFlat(xy, scale)`
 
 Unprojects a Web Mercator coordinate to longitude and latitude.
+
 | Parameter | Type | Default | Description |
 | -------------- | --------- | -------- | ------------------------------- |
 | `xy` | `Array` | (required) | Web Mercator coordinates, `[x, y]` |

--- a/modules/web-mercator/docs/api-reference/web-mercator-viewport.md
+++ b/modules/web-mercator/docs/api-reference/web-mercator-viewport.md
@@ -68,24 +68,24 @@ Returns: `[lng, lat]` or `[longitude, lat, Z]` in map coordinates. `Z` is elevat
 
 Project longitude and latitude onto Web Mercator coordinates.
 
-| Parameter | Type     | Default      | Description                   |
+| Parameter | Type | Default | Description |
 | --------- | -------- | ------------ | ----------------------------- |
-| `lngLat`  | `Array`  | (required)   | map coordinates, `[lng, lat]` |
-| `scale`   | `number` | `this.scale` | Web Mercator scale            |
+| `lngLat` | `Array` | (required) | map coordinates, `[lng, lat]` |
+| `scale` | `number` | `this.scale` | Web Mercator scale |
 
 Returns:
 
 - `[x, y]`, representing Web Mercator coordinates.
 
 ##### `unprojectFlat(xy, scale)`
-<!-- prettier-ignore-start -->
+
 Unprojects a Web Mercator coordinate to longitude and latitude.
 
 | Parameter | Type | Default | Description |
 | -------------- | --------- | -------- | ------------------------------- |
 | `xy` | `Array` | (required) | Web Mercator coordinates, `[x, y]` |
 | `scale` | `number` | `this.scale` | Web Mercator scale |
-<!-- prettier-ignore-end -->
+
 Returns:
 
 - `[longitude, latitude]`


### PR DESCRIPTION
It appears that ocular wants a newline after a sentence before a table starts. Not sure why this isn't happening on the Math.GL docs site but it's happening on ReactMapGL docs.

![image](https://user-images.githubusercontent.com/12652694/94186220-6b6a2000-fe74-11ea-90d8-90abfa4e5fed.png)

http://visgl.github.io/react-map-gl/docs/api-reference/web-mercator-viewport#unprojectflatxy-scale
