### PR TITLE
Fix get started link

### DIFF
--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -58,7 +58,7 @@ module.exports = {
         }
       ], // Other linked projects
 
-      LINK_TO_GET_STARTED: '/modules/core/docs/developer-guide/core-overview',
+      LINK_TO_GET_STARTED: '/docs',
 
       ADDITIONAL_LINKS: [{
         name: 'Blog',


### PR DESCRIPTION
The "Get Started" link on the math.gl homepage currently links to
```
https://math.gl/modules/core/docs/developer-guide/core-overview
```
which doesn't exist.