### PR TITLE
[polygon] Improve subdivision precision

### DIFF
--- a/modules/polygon/src/lineclip.js
+++ b/modules/polygon/src/lineclip.js
@@ -156,7 +156,7 @@ export function intersect(a, b, edge, bbox, out = []) {
     return null;
   }
   for (let i = 0; i < a.length; i++) {
-    out[i] = (snap & 1) === i ? bbox[snap] : t * b[i] + (1 - t) * a[i];
+    out[i] = (snap & 1) === i ? bbox[snap] : t * (b[i] - a[i]) + a[i];
   }
   return out;
 }

--- a/modules/polygon/test/cut-by-mercator-bounds.spec.js
+++ b/modules/polygon/test/cut-by-mercator-bounds.spec.js
@@ -2,30 +2,23 @@ import test from 'tape-catch';
 import {cutPolylineByMercatorBounds, cutPolygonByMercatorBounds} from '@math.gl/polygon';
 
 import {flatten} from './lineclip.spec';
-import {equals} from '@math.gl/core';
 
 test('cutPolylineByMercatorBounds - simple', t => {
-  t.ok(
-    equals(cutPolylineByMercatorBounds([-170, 0, 170, 20]), [
-      [-170, 0, -180, 10],
-      [180, 10, 170, 20]
-    ]),
+  t.deepEquals(
+    cutPolylineByMercatorBounds([-170, 0, 170, 20]),
+    [[-170, 0, -180, 10], [180, 10, 170, 20]],
     '2d'
   );
 
-  t.ok(
-    equals(cutPolylineByMercatorBounds([-170, 0, 100, 170, 20, 200], {size: 3}), [
-      [-170, 0, 100, -180, 10, 150],
-      [180, 10, 150, 170, 20, 200]
-    ]),
+  t.deepEquals(
+    cutPolylineByMercatorBounds([-170, 0, 100, 170, 20, 200], {size: 3}),
+    [[-170, 0, 100, -180, 10, 150], [180, 10, 150, 170, 20, 200]],
     '3d'
   );
 
-  t.ok(
-    equals(cutPolylineByMercatorBounds([-170, 0, 170, 20], {normalize: false}), [
-      [-170, 0, -180, 10],
-      [-180, 10, -190, 20]
-    ]),
+  t.deepEquals(
+    cutPolylineByMercatorBounds([-170, 0, 170, 20], {normalize: false}),
+    [[-170, 0, -180, 10], [-180, 10, -190, 20]],
     'normalize: false'
   );
 
@@ -36,14 +29,12 @@ test('cutPolylineByMercatorBounds - multiple crossings', t => {
   const result = cutPolylineByMercatorBounds([-170, 0, 170, 20, -175, 35, 175, 45]);
 
   t.comment(result);
-  t.ok(
-    equals(result, [
-      [-170, 0, -180, 10],
-      [180, 10, 170, 20, 180, 30],
-      [-180, 30, -175, 35, -180, 40],
-      [180, 40, 175, 45]
-    ])
-  );
+  t.deepEquals(result, [
+    [-170, 0, -180, 10],
+    [180, 10, 170, 20, 180, 30],
+    [-180, 30, -175, 35, -180, 40],
+    [180, 40, 175, 45]
+  ]);
 
   t.end();
 });
@@ -78,20 +69,21 @@ test('cutPolygonByMercatorBounds - simple', t => {
   const expectedB = [[-180, 20], [-170, 20], [-170, 0], [-180, 0]];
 
   let parts = cutPolygonByMercatorBounds(flatten(polygon));
-  t.ok(equals(parts[0].positions, flatten(expectedA)), '2d');
-  t.ok(equals(parts[1].positions, flatten(expectedB)), '2d');
+  t.deepEquals(parts[0].positions, flatten(expectedA), '2d');
+  t.deepEquals(parts[1].positions, flatten(expectedB), '2d');
 
   const flatten2 = (ring, accessPosition) => flatten(ring.map(accessPosition));
   const addZ = p => [p[0], p[1], 100];
 
   parts = cutPolygonByMercatorBounds(flatten2(polygon, addZ), null, {size: 3});
-  t.ok(equals(parts[0].positions, flatten2(expectedA, addZ)), '3d');
-  t.ok(equals(parts[1].positions, flatten2(expectedB, addZ)), '3d');
+  t.deepEquals(parts[0].positions, flatten2(expectedA, addZ), '3d');
+  t.deepEquals(parts[1].positions, flatten2(expectedB, addZ), '3d');
 
   parts = cutPolygonByMercatorBounds(flatten(polygon), null, {normalize: false});
-  t.ok(equals(parts[0].positions, flatten(expectedA)), 'normalize: false');
-  t.ok(
-    equals(parts[1].positions, flatten2(expectedB, p => [p[0] + 360, p[1]])),
+  t.deepEquals(parts[0].positions, flatten(expectedA), 'normalize: false');
+  t.deepEquals(
+    parts[1].positions,
+    flatten2(expectedB, p => [p[0] + 360, p[1]]),
     'normalize: false'
   );
 
@@ -108,19 +100,15 @@ test('cutPolygonByMercatorBounds - with holes', t => {
 
   let result = cutPolygonByMercatorBounds(flatten([polygon, holeA]), [8]);
   t.is(result.length, 2, 'Returns correct number of parts');
-  t.ok(
-    equals(result[0].positions, flatten([expectedA, holeA])) &&
-      equals(result[0].holeIndices, [8]) &&
-      equals(result[1].positions, flatten(expectedB))
-  );
+  t.deepEquals(result[0].positions, flatten([expectedA, holeA]), 'part 1 positions');
+  t.deepEquals(result[0].holeIndices, [8], 'part 1 holeIndices');
+  t.deepEquals(result[1].positions, flatten(expectedB), 'part 2 positions');
 
   result = cutPolygonByMercatorBounds(flatten([polygon, holeB]), [8]);
   t.is(result.length, 2, 'Returns correct number of parts');
-  t.ok(
-    equals(result[0].positions, flatten(expectedA)) &&
-      equals(result[1].positions, flatten([expectedB, holeB])) &&
-      equals(result[1].holeIndices, [8])
-  );
+  t.deepEquals(result[0].positions, flatten(expectedA), 'part 1 positions');
+  t.deepEquals(result[1].positions, flatten([expectedB, holeB]), 'part 2 positions');
+  t.deepEquals(result[1].holeIndices, [8], 'part 2 holeIndices');
 
   t.end();
 });
@@ -129,26 +117,22 @@ test('cutPolygonByMercatorBounds - contains pole', t => {
   const polygon = [[-150, 75], [-90, 80], [-30, 70], [30, 60], [90, 70], [150, 75]];
 
   const result = cutPolygonByMercatorBounds(flatten(polygon));
-  t.ok(
-    equals(
-      result[0].positions,
-      flatten([
-        [-90, 80],
-        [-30, 70],
-        [30, 60],
-        [90, 70],
-        [150, 75],
-        [180, 75],
-        [180, 85.051129],
-        [-90, 85.051129]
-      ])
-    )
+  t.deepEquals(
+    result[0].positions,
+    flatten([
+      [-90, 80],
+      [-30, 70],
+      [30, 60],
+      [90, 70],
+      [150, 75],
+      [180, 75],
+      [180, 85.051129],
+      [-90, 85.051129]
+    ])
   );
-  t.ok(
-    equals(
-      result[1].positions,
-      flatten([[-180, 75], [-150, 75], [-90, 80], [-90, 85.051129], [-180, 85.051129]])
-    )
+  t.deepEquals(
+    result[1].positions,
+    flatten([[-180, 75], [-150, 75], [-90, 80], [-90, 85.051129], [-180, 85.051129]])
   );
 
   t.end();

--- a/modules/polygon/test/lineclip.spec.js
+++ b/modules/polygon/test/lineclip.spec.js
@@ -1,5 +1,4 @@
 import test from 'tape-catch';
-import {equals} from '@math.gl/core';
 import {clipPolyline, clipPolygon} from '@math.gl/polygon';
 
 export function flatten(arr, result = []) {
@@ -34,14 +33,12 @@ test('clips line', t => {
   );
 
   t.comment(result);
-  t.ok(
-    equals(result, [
-      [0, 10, 10, 10, 10, 0],
-      [20, 0, 20, 10, 30, 10],
-      [30, 20, 20, 20, 20, 30],
-      [10, 30, 10, 20, 5, 20, 0, 20]
-    ])
-  );
+  t.deepEquals(result, [
+    [0, 10, 10, 10, 10, 0],
+    [20, 0, 20, 10, 30, 10],
+    [30, 20, 20, 20, 20, 30],
+    [10, 30, 10, 20, 5, 20, 0, 20]
+  ]);
 
   t.end();
 });
@@ -50,7 +47,7 @@ test('clips line crossing through many times', t => {
   const result = clipPolyline(flatten([[10, -10], [10, 30], [20, 30], [20, -10]]), [0, 0, 20, 20]);
 
   t.comment(result);
-  t.ok(equals(result, [[10, 0, 10, 20], [20, 20, 20, 0]]));
+  t.deepEquals(result, [[10, 0, 10, 20], [20, 20, 20, 0]]);
 
   t.end();
 });
@@ -63,7 +60,7 @@ test('clips 3d line', t => {
   );
 
   t.comment(result);
-  t.ok(equals(result, [[10, 0, 5, 10, 20, 15], [20, 20, 5, 20, 0, -5]]));
+  t.deepEquals(result, [[10, 0, 5, 10, 20, 15], [20, 20, 5, 20, 0, -5]]);
 
   t.end();
 });
@@ -76,7 +73,7 @@ test('clips line from partial array', t => {
   });
 
   t.comment(result);
-  t.ok(equals(result, [[10, 0, 10, 20], [20, 20, 20, 0]]));
+  t.deepEquals(result, [[10, 0, 10, 20], [20, 20, 20, 0]]);
 
   t.end();
 });
@@ -105,26 +102,24 @@ test('clips polygon', t => {
   );
 
   t.comment(result);
-  t.ok(
-    equals(
-      result,
-      flatten([
-        [0, 20],
-        [0, 10],
-        [10, 10],
-        [10, 5],
-        [10, 0],
-        [20, 0],
-        [20, 10],
-        [30, 10],
-        [30, 20],
-        [20, 20],
-        [20, 30],
-        [10, 30],
-        [10, 20],
-        [5, 20]
-      ])
-    )
+  t.deepEquals(
+    result,
+    flatten([
+      [0, 20],
+      [0, 10],
+      [10, 10],
+      [10, 5],
+      [10, 0],
+      [20, 0],
+      [20, 10],
+      [30, 10],
+      [30, 20],
+      [20, 20],
+      [20, 30],
+      [10, 30],
+      [10, 20],
+      [5, 20]
+    ])
   );
 
   t.end();
@@ -134,7 +129,7 @@ test('polygon contains bbox', t => {
   const result = clipPolygon(flatten([[10, 40], [40, 10], [10, -20], [-20, 10]]), [0, 0, 20, 20]);
 
   t.comment(result);
-  t.ok(equals(result, flatten([[0, 0], [0, 20], [20, 20], [20, 0]])));
+  t.deepEquals(result, flatten([[0, 0], [0, 20], [20, 20], [20, 0]]));
 
   t.end();
 });
@@ -147,20 +142,18 @@ test('clips 3d polygon', t => {
   );
 
   t.comment(result);
-  t.ok(
-    equals(
-      result,
-      flatten([
-        [0, 5, 8],
-        [5, 0, 4],
-        [15, 0, 4],
-        [20, 5, 8],
-        [20, 15, 16],
-        [15, 20, 20],
-        [5, 20, 20],
-        [0, 15, 16]
-      ])
-    )
+  t.deepEquals(
+    result,
+    flatten([
+      [0, 5, 8],
+      [5, 0, 4],
+      [15, 0, 4],
+      [20, 5, 8],
+      [20, 15, 16],
+      [15, 20, 20],
+      [5, 20, 20],
+      [0, 15, 16]
+    ])
   );
 
   t.end();
@@ -174,11 +167,9 @@ test('clips polygon fom partial array', t => {
   });
 
   t.comment(result);
-  t.ok(
-    equals(
-      result,
-      flatten([[0, 5], [5, 0], [15, 0], [20, 5], [20, 15], [15, 20], [5, 20], [0, 15]])
-    )
+  t.deepEquals(
+    result,
+    flatten([[0, 5], [5, 0], [15, 0], [20, 5], [20, 15], [15, 20], [5, 20], [0, 15]])
   );
 
   t.end();
@@ -200,15 +191,13 @@ test('clips floating point lines', t => {
   const result = clipPolyline(line, bbox);
 
   t.comment(result);
-  t.ok(
-    equals(result, [
-      flatten([
-        [-91.91208030440808, 42.29356419217009],
-        [-91.93359375, 42.32606244456202],
-        [-91.7578125, 42.3228109416169]
-      ])
+  t.deepEquals(result, [
+    flatten([
+      [-91.91208030440808, 42.29356419217009],
+      [-91.93359375, 42.32606244456202],
+      [-91.7578125, 42.3228109416169]
     ])
-  );
+  ]);
 
   t.end();
 });
@@ -217,7 +206,7 @@ test('preserves line if no protrusions exist', t => {
   const result = clipPolyline([1, 1, 2, 2, 3, 3], [0, 0, 30, 30]);
 
   t.comment(result);
-  t.ok(equals(result, [[1, 1, 2, 2, 3, 3]]));
+  t.deepEquals(result, [[1, 1, 2, 2, 3, 3]]);
 
   t.end();
 });


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/5123

`t * b[i] + (1 - t) * a[i]` has two precision roundings and `t * (b[i] - a[i]) + a[i]` has only one