### PR TITLE
Add a more detailed type definition for `WebMercatorViewport.getLocationAtPoint()`

### DIFF
--- a/modules/web-mercator/src/web-mercator-viewport.d.ts
+++ b/modules/web-mercator/src/web-mercator-viewport.d.ts
@@ -146,7 +146,7 @@ export default class WebMercatorViewport {
   getMapCenterByLngLatPosition({lngLat, pos}: {lngLat: number[], pos: number[]}): number[];
 
   /** @deprecated Legacy method name */
-  getLocationAtPoint({lngLat, pos}): number[];
+  getLocationAtPoint({lngLat, pos}: {lngLat: number[], pos: number[]}): number[];
 
   /**
    * Returns a new viewport that fit around the given rectangle.


### PR DESCRIPTION
The type definition for `WebMercatorViewport.getLocationAtPoint()` currently uses implicit any typing for `lngLat` and `pos`. This can cause TypeScript build errors if `noImplicitAny` is enabled and `skipLibCheck` is disabled:

```
node_modules/@math.gl/web-mercator/src/web-mercator-viewport.d.ts:149:23 - error TS7031:
Binding element 'lngLat' implicitly has an 'any' type.

149   getLocationAtPoint({lngLat, pos}): number[];

node_modules/@math.gl/web-mercator/src/web-mercator-viewport.d.ts:149:31 - error TS7031:
Binding element 'pos' implicitly has an 'any' type.

149   getLocationAtPoint({lngLat, pos}): number[];
```

This PR is a one-line change to add types for these arguments. The type signature for the function now matches the non-legacy `WebMercatorViewport.getMapCenterByLngLatPosition()` method (visible a few lines up in the diff). The legacy function simply calls and returns the non-legacy method with the same arguments, so these should have the same type signature:

```javascript
  // Legacy method name
  getLocationAtPoint({lngLat, pos}) {
    return this.getMapCenterByLngLatPosition({lngLat, pos});
  }
```