### PR TITLE
Handle missing log2 in IE 11

### DIFF
--- a/modules/web-mercator/src/fit-bounds.js
+++ b/modules/web-mercator/src/fit-bounds.js
@@ -1,6 +1,7 @@
 // @ts-nocheck TODO padding
 import WebMercatorViewport from './web-mercator-viewport';
 import assert from './assert';
+import {log2} from './math-utils';
 
 // Returns map settings {latitude, longitude, zoom}
 // that will contain the provided corners within the provided width.
@@ -71,7 +72,7 @@ export default function fitBounds({
   const center = [(se[0] + nw[0]) / 2 + offsetX, (se[1] + nw[1]) / 2 + offsetY];
 
   const centerLngLat = viewport.unproject(center);
-  const zoom = Math.min(maxZoom, viewport.zoom + Math.log2(Math.abs(Math.min(scaleX, scaleY))));
+  const zoom = Math.min(maxZoom, viewport.zoom + log2(Math.abs(Math.min(scaleX, scaleY))));
 
   assert(Number.isFinite(zoom));
 

--- a/modules/web-mercator/src/math-utils.js
+++ b/modules/web-mercator/src/math-utils.js
@@ -22,4 +22,4 @@ export function lerp(start, end, step) {
 }
 
 // Handle missing log2 in IE 11
-export let log2 = Math.log2 || function(x){ return Math.log(x) * Math.LOG2E; };
+export const log2 = Math.log2 || function(x){ return Math.log(x) * Math.LOG2E; };

--- a/modules/web-mercator/src/math-utils.js
+++ b/modules/web-mercator/src/math-utils.js
@@ -20,3 +20,6 @@ export function mod(value, divisor) {
 export function lerp(start, end, step) {
   return step * end + (1 - step) * start;
 }
+
+// Handle missing log2 in IE 11
+export let log2 = Math.log2 || function(x){ return Math.log(x) * Math.LOG2E; };

--- a/modules/web-mercator/src/normalize-viewport-props.js
+++ b/modules/web-mercator/src/normalize-viewport-props.js
@@ -1,5 +1,5 @@
 import WebMercatorViewport from './web-mercator-viewport';
-import {mod} from './math-utils';
+import {mod, log2} from './math-utils';
 
 // defined by mapbox-gl
 const MAX_LATITUDE = 85.05113;
@@ -33,7 +33,7 @@ export default function normalizeViewportProps({
   if (bottomY - topY < height) {
     // Map height must not be smaller than viewport height
     // Zoom out map to fit map height into viewport
-    zoom += Math.log2(height / (bottomY - topY));
+    zoom += log2(height / (bottomY - topY));
 
     // Calculate top and bottom using new zoom
     flatViewport = new WebMercatorViewport({width, height, longitude, latitude, zoom});

--- a/modules/web-mercator/src/web-mercator-utils.js
+++ b/modules/web-mercator/src/web-mercator-utils.js
@@ -1,6 +1,6 @@
 // TODO - THE UTILITIES IN THIS FILE SHOULD BE IMPORTED FROM WEB-MERCATOR-VIEWPORT MODULE
 
-import {createMat4, transformVector} from './math-utils';
+import {createMat4, transformVector, log2} from './math-utils';
 
 import * as mat4 from 'gl-matrix/mat4';
 import * as vec2 from 'gl-matrix/vec2';
@@ -25,7 +25,7 @@ export function zoomToScale(zoom) {
 }
 
 export function scaleToZoom(scale) {
-  return Math.log2(scale);
+  return log2(scale);
 }
 
 /**


### PR DESCRIPTION
We had an error in prod today, in fit-bounds.js, `Object doesn't support property or method 'log2'`. 
Internet Explorer 11, Windows 10. 

Looks like another library had the same issue, and it's IE11 related. 
https://github.com/tangrams/tangram/issues/473

I couldn't tell if you intend to support IE 11, but the fix is so small I figured I'd send a PR anyway (by copying from the solution tangram used)