### PR TITLE
WebMercatorViewport supports camera meter offset

### DIFF
--- a/modules/web-mercator/docs/api-reference/web-mercator-viewport.md
+++ b/modules/web-mercator/docs/api-reference/web-mercator-viewport.md
@@ -9,16 +9,17 @@ and performs projections between world and screen coordinates.
 
 ## Constructor
 
-| Parameter   | Type     | Default | Description                                                                                      |
-| ----------- | -------- | ------- | ------------------------------------------------------------------------------------------------ |
-| `width`     | `number` | `1`     | Width of viewport                                                                                |
-| `height`    | `number` | `1`     | Height of viewport                                                                               |
-| `latitude`  | `number` | `0`     | Latitude of viewport center                                                                      |
-| `longitude` | `number` | `0`     | Longitude of viewport center                                                                     |
-| `zoom`      | `number` | `11`    | Map zoom (scale is calculated as `2^zoom`)                                                       |
-| `pitch`     | `number` | `0`     | The pitch (tilt) of the map from the screen, in degrees (0 is straight down)                     |
-| `bearing`   | `number` | `0`     | The bearing (rotation) of the map from north, in degrees counter-clockwise (0 means north is up) |
-| `altitude`  | `number` | `1.5`   | Altitude of camera in screen units                                                               |
+| Parameter   | Type       | Default | Description                                                                                      |
+| ----------- | ---------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `width`     | `number`   | `1`     | Width of viewport                                                                                |
+| `height`    | `number`   | `1`     | Height of viewport                                                                               |
+| `latitude`  | `number`   | `0`     | Latitude of viewport center                                                                      |
+| `longitude` | `number`   | `0`     | Longitude of viewport center                                                                     |
+| `zoom`      | `number`   | `11`    | Map zoom (scale is calculated as `2^zoom`)                                                       |
+| `pitch`     | `number`   | `0`     | The pitch (tilt) of the map from the screen, in degrees (0 is straight down)                     |
+| `bearing`   | `number`   | `0`     | The bearing (rotation) of the map from north, in degrees counter-clockwise (0 means north is up) |
+| `altitude`  | `number`   | `1.5`   | Altitude of camera in screen units                                                               |
+| `position`  | `number[]` | `null`  | Offset of the camera, in meters                                                                  |
 
 Remarks:
 

--- a/modules/web-mercator/src/web-mercator-viewport.d.ts
+++ b/modules/web-mercator/src/web-mercator-viewport.d.ts
@@ -6,6 +6,7 @@ type WebMercatorViewportOptions = {
   height: number;
   latitude?: number;
   longitude?: number;
+  position?: number[];
   zoom?: number;
   pitch?: number;
   bearing?: number;
@@ -28,6 +29,7 @@ export default class WebMercatorViewport {
   bearing: number;
   altitude: number;
 
+  meterOffset: number[];
   center: number[];
 
   width: number;

--- a/modules/web-mercator/src/web-mercator-viewport.js
+++ b/modules/web-mercator/src/web-mercator-viewport.js
@@ -16,6 +16,7 @@ import getBounds from './get-bounds';
 
 import * as mat4 from 'gl-matrix/mat4';
 import * as vec2 from 'gl-matrix/vec2';
+import * as vec3 from 'gl-matrix/vec3';
 
 export default class WebMercatorViewport {
   // eslint-disable-next-line max-statements
@@ -30,6 +31,7 @@ export default class WebMercatorViewport {
       pitch = 0,
       bearing = 0,
       altitude = 1.5,
+      position = null,
       nearZMultiplier = 0.02,
       farZMultiplier = 1.01
     } = {width: 1, height: 1}
@@ -43,8 +45,14 @@ export default class WebMercatorViewport {
     // TODO - just throw an Error instead?
     altitude = Math.max(0.75, altitude);
 
+    const distanceScales = getDistanceScales({longitude, latitude});
+
     const center = lngLatToWorld([longitude, latitude]);
     center[2] = 0;
+
+    if (position) {
+      vec3.add(center, center, vec3.mul([], position, distanceScales.unitsPerMeter));
+    }
 
     this.projectionMatrix = getProjectionMatrix({
       width,
@@ -76,8 +84,9 @@ export default class WebMercatorViewport {
     this.bearing = bearing;
     this.altitude = altitude;
     this.center = center;
+    this.meterOffset = position || [0, 0, 0];
 
-    this.distanceScales = getDistanceScales(this);
+    this.distanceScales = distanceScales;
 
     this._initMatrices();
 

--- a/modules/web-mercator/test/spec/web-mercator-viewport.spec.js
+++ b/modules/web-mercator/test/spec/web-mercator-viewport.spec.js
@@ -31,6 +31,16 @@ test('WebMercatorViewport#constructor - 0 width/height', t => {
   t.end();
 });
 
+test('WebMercatorViewport#constructor - camera offset', t => {
+  const viewport = new WebMercatorViewport(
+    Object.assign({}, VIEWPORT_PROPS.flat, {
+      position: [0, 0, 300]
+    })
+  );
+  t.ok(viewport.center[2], 'WebMercatorViewport constructed successfully with camera offset');
+  t.end();
+});
+
 test('WebMercatorViewport#equals', t => {
   // TODO - fix types
   // @ts-ignore


### PR DESCRIPTION
Needed for react-map-gl to support Mapbox terrain. Names are aligned with deck.gl's `Viewport` class.


Change list:

- Add `position` to `WebMercatorViewport` constructor
- Add `meterOffset` field to viewport instance
- Docs
- Unit test