### PR TITLE
[fix] makeBoundingSphereFromPoints inconsistent result

### DIFF
--- a/modules/culling/src/lib/algorithms/bounding-sphere-from-points.js
+++ b/modules/culling/src/lib/algorithms/bounding-sphere-from-points.js
@@ -43,27 +43,27 @@ export default function makeBoundingSphereFromPoints(positions, result = new Bou
 
     // Store points containing the the smallest and largest components
     if (x < xMin.x) {
-      currentPos.copy(xMin);
+      xMin.copy(currentPos);
     }
 
     if (x > xMax.x) {
-      currentPos.copy(xMax);
+      xMax.copy(currentPos);
     }
 
     if (y < yMin.y) {
-      currentPos.copy(yMin);
+      yMin.copy(currentPos);
     }
 
     if (y > yMax.y) {
-      currentPos.copy(yMax);
+      yMax.copy(currentPos);
     }
 
     if (z < zMin.z) {
-      currentPos.copy(zMin);
+      zMin.copy(currentPos);
     }
 
     if (z > zMax.z) {
-      currentPos.copy(zMax);
+      zMax.copy(currentPos);
     }
   }
 

--- a/modules/culling/test/lib/algorithms/bounding-sphere-from-points.spec.js
+++ b/modules/culling/test/lib/algorithms/bounding-sphere-from-points.spec.js
@@ -7,12 +7,7 @@ import {tapeEquals} from 'test/utils/tape-assertions';
 import {Vector3} from '@math.gl/core';
 import {makeBoundingSphereFromPoints} from '@math.gl/culling';
 
-const positionsRadius = 1.0;
-const positionsCenter = new Vector3(10000001.0, 0.0, 0.0);
-
-const center = [10000000.0, 0.0, 0.0];
-
-function getPositions() {
+function getPositions(center) {
   return [
     new Vector3(center).add([1, -1, 0]),
     new Vector3(center).add([1, 0, 0]),
@@ -33,7 +28,7 @@ test('makeBoundingSphereFromPoints without positions returns an empty sphere', (
 });
 
 test('makeBoundingSphereFromPoints works with one point', (t) => {
-  const expectedCenter = new Vector3(1.0, 2.0, 3.0);
+  const expectedCenter = [1.0, 2.0, 3.0];
   const sphere = makeBoundingSphereFromPoints([expectedCenter]);
   tapeEquals(t, sphere.center, expectedCenter);
   t.equals(sphere.radius, 0.0);
@@ -42,7 +37,11 @@ test('makeBoundingSphereFromPoints works with one point', (t) => {
 });
 
 test('makeBoundingSphereFromPoints computes a center from points', (t) => {
-  const sphere = makeBoundingSphereFromPoints(getPositions());
+  const positionsRadius = 1.0;
+  const positionsCenter = [10000001.0, 0.0, 0.0];
+  const center = [10000000.0, 0.0, 0.0];
+
+  const sphere = makeBoundingSphereFromPoints(getPositions(center));
   tapeEquals(t, sphere.center, positionsCenter);
   t.equals(sphere.radius, positionsRadius);
 
@@ -50,7 +49,7 @@ test('makeBoundingSphereFromPoints computes a center from points', (t) => {
 });
 
 test('makeBoundingSphereFromPoints contains all points (naive)', (t) => {
-  const positions = getPositions();
+  const positions = getPositions([0, 0, 0]);
   const sphere = makeBoundingSphereFromPoints(positions);
   const radius = sphere.radius;
 
@@ -65,7 +64,7 @@ test('makeBoundingSphereFromPoints contains all points (naive)', (t) => {
 });
 
 test('makeBoundingSphereFromPoints contains all points (ritter)', (t) => {
-  const positions = getPositions();
+  const positions = getPositions([0, 0, 0]);
   positions.push(new Vector3(1, 1, 1), new Vector3(2, 2, 2), new Vector3(3, 3, 3));
   const sphere = makeBoundingSphereFromPoints(positions);
   const radius = sphere.radius;

--- a/modules/culling/test/lib/algorithms/bounding-sphere-from-points.spec.js
+++ b/modules/culling/test/lib/algorithms/bounding-sphere-from-points.spec.js
@@ -14,11 +14,11 @@ const center = [10000000.0, 0.0, 0.0];
 
 function getPositions() {
   return [
+    new Vector3(center).add([1, -1, 0]),
     new Vector3(center).add([1, 0, 0]),
     new Vector3(center).add([2, 0, 0]),
     new Vector3(center).add([0, 0, 0]),
     new Vector3(center).add([1, 1, 0]),
-    new Vector3(center).add([1, -1, 0]),
     new Vector3(center).add([1, 0, 1]),
     new Vector3(center).add([1, 0, -1])
   ];
@@ -50,20 +50,15 @@ test('makeBoundingSphereFromPoints computes a center from points', (t) => {
 });
 
 test('makeBoundingSphereFromPoints contains all points (naive)', (t) => {
-  const sphere = makeBoundingSphereFromPoints(getPositions());
+  const positions = getPositions();
+  const sphere = makeBoundingSphereFromPoints(positions);
   const radius = sphere.radius;
 
-  const r = new Vector3(radius, radius, radius);
-  const max = sphere.center.clone().add(r);
-  const min = sphere.center.clone().subtract(r);
-
-  const positions = getPositions();
   const numPositions = positions.length;
   for (let i = 0; i < numPositions; i++) {
     const currentPos = positions[i];
-    t.equals(currentPos.x <= max.x && currentPos.x >= min.x, true);
-    t.equals(currentPos.y <= max.y && currentPos.y >= min.y, true);
-    t.equals(currentPos.z <= max.z && currentPos.z >= min.z, true);
+    const deltaToCenter = currentPos.subtract(sphere.center);
+    t.ok(deltaToCenter.len() <= radius);
   }
 
   t.end();
@@ -75,16 +70,11 @@ test('makeBoundingSphereFromPoints contains all points (ritter)', (t) => {
   const sphere = makeBoundingSphereFromPoints(positions);
   const radius = sphere.radius;
 
-  const r = new Vector3(radius, radius, radius);
-  const max = sphere.center.clone().add(r);
-  const min = sphere.center.clone().subtract(r);
-
   const numPositions = positions.length;
   for (let i = 0; i < numPositions; i++) {
     const currentPos = positions[i];
-    t.equals(currentPos.x <= max.x && currentPos.x >= min.x, true);
-    t.equals(currentPos.y <= max.y && currentPos.y >= min.y, true);
-    t.equals(currentPos.z <= max.z && currentPos.z >= min.z, true);
+    const deltaToCenter = currentPos.subtract(sphere.center);
+    t.ok(deltaToCenter.len() <= radius);
   }
 
   t.end();


### PR DESCRIPTION
The result of `makeBoundingSphereFromPoints` is dependent on the order of input points due to the incorrect population of min/max positions.