### PR TITLE
[fix] makeOrientedBoundingBoxFromPoints crash

### DIFF
--- a/modules/culling/src/lib/algorithms/bounding-box-from-points.js
+++ b/modules/culling/src/lib/algorithms/bounding-box-from-points.js
@@ -89,13 +89,15 @@ export function makeOrientedBoundingBoxFromPoints(positions, result = new Orient
   let l3 = Number.MAX_VALUE;
 
   for (const position of positions) {
-    u1 = Math.max(position.dot(v1), u1);
-    u2 = Math.max(position.dot(v2), u2);
-    u3 = Math.max(position.dot(v3), u3);
+    scratchVector2.copy(position);
 
-    l1 = Math.min(position.dot(v1), l1);
-    l2 = Math.min(position.dot(v2), l2);
-    l3 = Math.min(position.dot(v3), l3);
+    u1 = Math.max(scratchVector2.dot(v1), u1);
+    u2 = Math.max(scratchVector2.dot(v2), u2);
+    u3 = Math.max(scratchVector2.dot(v3), u3);
+
+    l1 = Math.min(scratchVector2.dot(v1), l1);
+    l2 = Math.min(scratchVector2.dot(v2), l2);
+    l3 = Math.min(scratchVector2.dot(v3), l3);
   }
 
   v1 = v1.multiplyByScalar(0.5 * (l1 + u1));

--- a/modules/culling/test/index.js
+++ b/modules/culling/test/index.js
@@ -5,6 +5,7 @@
 
 import './lib/algorithms/compute-eigen-decomposition.spec';
 import './lib/algorithms/bounding-sphere-from-points.spec';
+import './lib/algorithms/bounding-box-from-points.spec';
 
 import './lib/bounding-volumes/axis-aligned-bounding-box.spec';
 import './lib/bounding-volumes/bounding-sphere.spec';

--- a/modules/culling/test/lib/algorithms/bounding-box-from-points.spec.js
+++ b/modules/culling/test/lib/algorithms/bounding-box-from-points.spec.js
@@ -1,0 +1,43 @@
+import test from 'tape-promise/tape';
+import {
+  makeOrientedBoundingBoxFromPoints,
+  makeAxisAlignedBoundingBoxFromPoints
+} from '@math.gl/culling';
+import {Vector3, equals} from '@math.gl/core';
+
+const testPoints = [
+  [1, 0, 0],
+  [2, 0, 0],
+  [0, 0, 0],
+  [1, 1, 2]
+];
+
+test('makeOrientedBoundingBoxFromPoints#empty', (t) => {
+  const boundingBox = makeOrientedBoundingBoxFromPoints([]);
+  t.ok(equals(boundingBox.center, Vector3.ZERO));
+  t.ok(equals(boundingBox.halfSize, Vector3.ZERO));
+  t.end();
+});
+
+test('makeOrientedBoundingBoxFromPoints#one point', (t) => {
+  const point = [1, 2, 3];
+  const boundingBox = makeOrientedBoundingBoxFromPoints([point]);
+  t.ok(equals(boundingBox.center, point));
+  t.ok(equals(boundingBox.halfSize, Vector3.ZERO));
+  t.end();
+});
+
+test('makeOrientedBoundingBoxFromPoints', (t) => {
+  const boundingBox = makeOrientedBoundingBoxFromPoints(testPoints);
+  for (const point of testPoints) {
+    t.ok(equals(boundingBox.distanceTo(point), 0), 'point is inside the bounding box');
+  }
+  t.end();
+});
+
+test('makeAxisAlignedBoundingBoxFromPoints', (t) => {
+  const boundingBox = makeAxisAlignedBoundingBoxFromPoints(testPoints);
+  t.ok(equals(boundingBox.center, [1, 0.5, 1]));
+  t.ok(equals(boundingBox.halfDiagonal, [1, 0.5, 1]));
+  t.end();
+});


### PR DESCRIPTION
The funciton crashes when `points` are plain arrays instead of `Vector3`.