### PR TITLE
[web-mercator] Improve viewport normalization

### DIFF
--- a/modules/web-mercator/src/normalize-viewport-props.js
+++ b/modules/web-mercator/src/normalize-viewport-props.js
@@ -23,11 +23,13 @@ export default function normalizeViewportProps({
     bearing = mod(bearing + 180, 360) - 180;
   }
 
+  // Constrain zoom and shift center at low zoom levels
   const minZoom = log2(height / TILE_SIZE);
   if (zoom <= minZoom) {
     zoom = minZoom;
     latitude = 0;
   } else {
+    // Eliminate white space above and below the map
     const halfHeightPixels = height / 2 / Math.pow(2, zoom);
     const minLatitude = worldToLngLat([0, halfHeightPixels])[1];
     if (latitude < minLatitude) {

--- a/modules/web-mercator/src/normalize-viewport-props.js
+++ b/modules/web-mercator/src/normalize-viewport-props.js
@@ -1,9 +1,8 @@
-import WebMercatorViewport from './web-mercator-viewport';
+import {worldToLngLat} from './web-mercator-utils';
 import {mod, log2} from './math-utils';
 
 // defined by mapbox-gl
-const MAX_LATITUDE = 85.05113;
-const MIN_LATITUDE = -85.05113;
+const TILE_SIZE = 512;
 
 // Apply mathematical constraints to viewport props
 // eslint-disable-next-line complexity
@@ -24,31 +23,21 @@ export default function normalizeViewportProps({
     bearing = mod(bearing + 180, 360) - 180;
   }
 
-  // Constrain zoom and shift center at low zoom levels
-  let flatViewport = new WebMercatorViewport({width, height, longitude, latitude, zoom});
-  let topY = flatViewport.project([longitude, MAX_LATITUDE])[1];
-  let bottomY = flatViewport.project([longitude, MIN_LATITUDE])[1];
-  let shiftY = 0;
-
-  if (bottomY - topY < height) {
-    // Map height must not be smaller than viewport height
-    // Zoom out map to fit map height into viewport
-    zoom += log2(height / (bottomY - topY));
-
-    // Calculate top and bottom using new zoom
-    flatViewport = new WebMercatorViewport({width, height, longitude, latitude, zoom});
-    topY = flatViewport.project([longitude, MAX_LATITUDE])[1];
-    bottomY = flatViewport.project([longitude, MIN_LATITUDE])[1];
-  }
-  if (topY > 0) {
-    // Compensate for white gap on top
-    shiftY = topY;
-  } else if (bottomY < height) {
-    // Compensate for white gap on bottom
-    shiftY = bottomY - height;
-  }
-  if (shiftY) {
-    latitude = flatViewport.unproject([width / 2, height / 2 + shiftY])[1];
+  const minZoom = log2(height / TILE_SIZE);
+  if (zoom <= minZoom) {
+    zoom = minZoom;
+    latitude = 0;
+  } else {
+    const halfHeightPixels = height / 2 / Math.pow(2, zoom);
+    const minLatitude = worldToLngLat([0, halfHeightPixels])[1];
+    if (latitude < minLatitude) {
+      latitude = minLatitude;
+    } else {
+      const maxLatitude = worldToLngLat([0, TILE_SIZE - halfHeightPixels])[1];
+      if (latitude > maxLatitude) {
+        latitude = maxLatitude;
+      }
+    }
   }
 
   return {width, height, longitude, latitude, zoom, pitch, bearing};

--- a/modules/web-mercator/test/spec/normalize-viewport-props.spec.js
+++ b/modules/web-mercator/test/spec/normalize-viewport-props.spec.js
@@ -18,7 +18,7 @@ const NORMALIZATION_TEST_CASES = [
       height: 600,
       latitude: 0,
       longitude: 160,
-      zoom: 0.22881857712872292,
+      zoom: 0.22881869049588088,
       bearing: -160,
       pitch: 60
     }
@@ -28,17 +28,37 @@ const NORMALIZATION_TEST_CASES = [
       width: 1000,
       height: 1000,
       longitude: 80,
-      latitude: 80,
-      zoom: 0,
+      latitude: -50,
+      zoom: 1,
       pitch: 0,
       bearing: 0
     },
     {
       width: 1000,
       height: 1000,
-      latitude: 0,
+      latitude: -4.214943141390651,
       longitude: 80,
-      zoom: 0.9657841712949484,
+      zoom: 1,
+      bearing: 0,
+      pitch: 0
+    }
+  ],
+  [
+    {
+      width: 1000,
+      height: 1000,
+      longitude: 80,
+      latitude: 80,
+      zoom: 1,
+      pitch: 0,
+      bearing: 0
+    },
+    {
+      width: 1000,
+      height: 1000,
+      latitude: 4.214943141390651,
+      longitude: 80,
+      zoom: 1,
       bearing: 0,
       pitch: 0
     }

--- a/modules/web-mercator/test/spec/normalize-viewport-props.spec.js
+++ b/modules/web-mercator/test/spec/normalize-viewport-props.spec.js
@@ -8,7 +8,7 @@ const NORMALIZATION_TEST_CASES = [
       width: 800,
       height: 600,
       longitude: -200,
-      latitude: 0,
+      latitude: 10,
       zoom: 0,
       pitch: 60,
       bearing: 200
@@ -21,6 +21,26 @@ const NORMALIZATION_TEST_CASES = [
       zoom: 0.22881869049588088,
       bearing: -160,
       pitch: 60
+    }
+  ],
+  [
+    {
+      width: 1000,
+      height: 1000,
+      longitude: 80,
+      latitude: 0,
+      zoom: 1,
+      pitch: 0,
+      bearing: 0
+    },
+    {
+      width: 1000,
+      height: 1000,
+      latitude: 0,
+      longitude: 80,
+      zoom: 1,
+      bearing: 0,
+      pitch: 0
     }
   ],
   [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3779,9 +3779,9 @@ camelcase@^5.0.0, camelcase@^5.2.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001245"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz"
-  integrity sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==
+  version "1.0.30001251"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz"
+  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
For https://github.com/visgl/react-map-gl/issues/1531

Before this change, clamped zoom/latitude values at low zoom are affected by their input due to precision loss in `WebMercatorViewport.project`/`unproject`. After this change, they are only determined by `height`.