### PR TITLE
Pin gl-matrix to ~3.3.0

### DIFF
--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "gl-matrix": "^3.0.0"
+    "gl-matrix": ">3.0.0 <=3.3.0"
   },
   "gitHead": "e1a95300cb225a90da6e90333d4adf290f7ba501"
 }

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "gl-matrix": ">3.0.0 <=3.3.0"
+    "gl-matrix": "~3.3.0"
   },
   "gitHead": "e1a95300cb225a90da6e90333d4adf290f7ba501"
 }

--- a/modules/culling/package.json
+++ b/modules/culling/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.0",
     "@math.gl/core": "3.5.5",
-    "gl-matrix": ">3.0.0 <=3.3.0"
+    "gl-matrix": "~3.3.0"
   },
   "gitHead": "e1a95300cb225a90da6e90333d4adf290f7ba501"
 }

--- a/modules/culling/package.json
+++ b/modules/culling/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.0",
     "@math.gl/core": "3.5.5",
-    "gl-matrix": "^3.0.0"
+    "gl-matrix": ">3.0.0 <=3.3.0"
   },
   "gitHead": "e1a95300cb225a90da6e90333d4adf290f7ba501"
 }

--- a/modules/geospatial/package.json
+++ b/modules/geospatial/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.0",
     "@math.gl/core": "3.5.5",
-    "gl-matrix": "^3.0.0"
+    "gl-matrix": ">3.0.0 <=3.3.0"
   },
   "gitHead": "e1a95300cb225a90da6e90333d4adf290f7ba501"
 }

--- a/modules/geospatial/package.json
+++ b/modules/geospatial/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.0",
     "@math.gl/core": "3.5.5",
-    "gl-matrix": ">3.0.0 <=3.3.0"
+    "gl-matrix": "~3.3.0"
   },
   "gitHead": "e1a95300cb225a90da6e90333d4adf290f7ba501"
 }

--- a/modules/web-mercator/package.json
+++ b/modules/web-mercator/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "gl-matrix": ">3.0.0 <=3.3.0"
+    "gl-matrix": "~3.3.0"
   },
   "devDependencies": {
     "mapbox-gl": "^1.0.0",

--- a/modules/web-mercator/package.json
+++ b/modules/web-mercator/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "gl-matrix": "^3.0.0"
+    "gl-matrix": ">3.0.0 <=3.3.0"
   },
   "devDependencies": {
     "mapbox-gl": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "gl-matrix": "^3.0.0"
+    "gl-matrix": ">3.0.0 <=3.3.0"
   },
   "devDependencies": {
     "@babel/register": "^7.13.16",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "gl-matrix": ">3.0.0 <=3.3.0"
+    "gl-matrix": "~3.3.0"
   },
   "devDependencies": {
     "@babel/register": "^7.13.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3779,9 +3779,9 @@ camelcase@^5.0.0, camelcase@^5.2.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001251"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz"
-  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
+  version "1.0.30001264"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz"
+  integrity sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -6025,7 +6025,7 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-gl-matrix@^3.0.0, gl-matrix@^3.2.1:
+gl-matrix@^3.2.1, gl-matrix@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.3.0.tgz#232eef60b1c8b30a28cbbe75b2caf6c48fd6358b"
   integrity sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA==


### PR DESCRIPTION
Ref https://github.com/uber-web/math.gl/issues/252#issuecomment-934695063, https://github.com/toji/gl-matrix/issues/439. This is a quick fix to prevent installing the latest 3.4.1 version of gl-matrix, which is causing install problems for users.

I think these are all the modules that require `gl-matrix`.