### PR TITLE
chore: Add typescript monorepo build setup

### DIFF
--- a/modules/core/tsconfig.json
+++ b/modules/core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+  ]
+}

--- a/modules/culling/tsconfig.json
+++ b/modules/culling/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {"path": "../core"}
+  ]
+}

--- a/modules/geoid/package.json
+++ b/modules/geoid/package.json
@@ -33,9 +33,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "@math.gl/core": "3.5.6",
-    "@types/proj4": "^2.5.0",
-    "proj4": "^2.6.2"
+    "@math.gl/core": "3.5.6"
   },
   "gitHead": "e1a95300cb225a90da6e90333d4adf290f7ba501"
 }

--- a/modules/geoid/tsconfig.json
+++ b/modules/geoid/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {"path": "../core"}
+  ]
+}

--- a/modules/geospatial/tsconfig.json
+++ b/modules/geospatial/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {"path": "../core"}
+  ]
+}

--- a/modules/main/tsconfig.json
+++ b/modules/main/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {"path": "../core"}
+  ]
+}

--- a/modules/polygon/tsconfig.json
+++ b/modules/polygon/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {"path": "../core"}
+  ]
+}

--- a/modules/proj4/tsconfig.json
+++ b/modules/proj4/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    {"path": "../core"}
+  ]
+}

--- a/modules/sun/tsconfig.json
+++ b/modules/sun/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+  ]
+}

--- a/modules/web-mercator/tsconfig.json
+++ b/modules/web-mercator/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": []
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "bootstrap": "PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn && ocular-bootstrap",
     "build": "ocular-clean && ocular-build",
+    "tsclean": "find . -name tsconfig.tsbuildinfo -exec rm {} \\;",
+    "tsbuild": "time npx tsc -b tsconfig.modules.json",
     "cover": "ocular-test cover",
     "lint": "tsc && ocular-lint",
     "metrics": "ocular-metrics",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,16 @@
+// This is a base TS config to be extended by the individual packages
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "build": true,
+    "target": "es2020",
+    "module": "es2020",
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    // "emitDeclarationOnly": true
+    // Uncomment to debug
+    // "listEmittedFiles": true
+  }
+}

--- a/tsconfig.modules.json
+++ b/tsconfig.modules.json
@@ -1,0 +1,38 @@
+// This is the monorepo build config
+// needs to be a separate file to avoid importing references into packages
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "build": true,
+    "module": "ES2020",
+    "esModuleInterop": true,
+    "declaration": true,
+    // Source map for declarations... not currently needed
+    // "declarationMap": true,
+    "noEmit": true,
+    // "emitDeclarationOnly": true,
+    // Uncomment to debug
+    "listEmittedFiles": true
+  },
+  // Monorepo setup. All modules need to be listed here
+  "references": [
+    {"path": "modules/core"},
+    {"path": "modules/culling"},
+    {"path": "modules/geoid"},
+    {"path": "modules/geospatial"},
+    {"path": "modules/main"},
+    {"path": "modules/polygon"},
+    {"path": "modules/proj4"},
+    {"path": "modules/sun"},
+    {"path": "modules/web-mercator"}
+  ],
+  "include": [
+    "modules"
+  ],
+  "exclude": [
+    "examples",
+    "test",
+    "modules/*/test",
+    "modules/*/dist"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9237,14 +9237,6 @@ proj4@2.6.2:
     mgrs "1.0.0"
     wkt-parser "^1.2.4"
 
-proj4@^2.6.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/proj4/-/proj4-2.7.2.tgz#faa42e5965aa275af5438ba2da8c59d1cc501137"
-  integrity sha512-x/EboBmIq48a9FED0Z9zWCXkd8VIpXHLsyEXljGtsnzeztC41bFjPjJ0S//wBbNLDnDYRe0e6c3FSSiqMCebDA==
-  dependencies:
-    mgrs "1.0.0"
-    wkt-parser "^1.2.4"
-
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"


### PR DESCRIPTION
- Adds new tsbuild and tsclean scripts but does not yet replace the ocular build.