### PR TITLE
[web-mercator] fitBounds respects Web Mercator bounds

### DIFF
--- a/modules/web-mercator/src/fit-bounds.ts
+++ b/modules/web-mercator/src/fit-bounds.ts
@@ -1,6 +1,6 @@
-import WebMercatorViewport from './web-mercator-viewport';
 import assert from './assert';
-import {log2} from './math-utils';
+import {log2, clamp} from './math-utils';
+import {MAX_LATITUDE, lngLatToWorld, worldToLngLat} from './web-mercator-utils';
 
 /**
  * Options for fitBounds
@@ -66,16 +66,8 @@ export default function fitBounds(options: FitBoundsOptions): Bounds {
   const [[west, south], [east, north]] = bounds;
   const padding = getPaddingObject(options.padding);
 
-  const viewport = new WebMercatorViewport({
-    width,
-    height,
-    longitude: 0,
-    latitude: 0,
-    zoom: 0
-  });
-
-  const nw = viewport.project([west, north]);
-  const se = viewport.project([east, south]);
+  const nw = lngLatToWorld([west, clamp(north, -MAX_LATITUDE, MAX_LATITUDE)]);
+  const se = lngLatToWorld([east, clamp(south, -MAX_LATITUDE, MAX_LATITUDE)]);
 
   // width/height on the Web Mercator plane
   const size = [
@@ -100,8 +92,8 @@ export default function fitBounds(options: FitBoundsOptions): Bounds {
 
   const center = [(se[0] + nw[0]) / 2 + offsetX, (se[1] + nw[1]) / 2 + offsetY];
 
-  const centerLngLat = viewport.unproject(center);
-  const zoom = Math.min(maxZoom, viewport.zoom + log2(Math.abs(Math.min(scaleX, scaleY))));
+  const centerLngLat = worldToLngLat(center);
+  const zoom = Math.min(maxZoom, log2(Math.abs(Math.min(scaleX, scaleY))));
 
   assert(Number.isFinite(zoom));
 

--- a/modules/web-mercator/src/index.ts
+++ b/modules/web-mercator/src/index.ts
@@ -8,6 +8,7 @@ export {default as normalizeViewportProps} from './normalize-viewport-props';
 export {default as flyToViewport, getFlyToDuration} from './fly-to-viewport';
 
 export {
+  MAX_LATITUDE,
   lngLatToWorld,
   worldToLngLat,
   worldToPixels,

--- a/modules/web-mercator/src/math-utils.ts
+++ b/modules/web-mercator/src/math-utils.ts
@@ -21,6 +21,10 @@ export function lerp(start: number, end: number, step: number): number {
   return step * end + (1 - step) * start;
 }
 
+export function clamp(x: number, min: number, max: number) {
+  return x < min ? min : x > max ? max : x;
+}
+
 function ieLog2(x: number): number {
   return Math.log(x) * Math.LOG2E;
 }

--- a/modules/web-mercator/src/web-mercator-utils.ts
+++ b/modules/web-mercator/src/web-mercator-utils.ts
@@ -15,6 +15,8 @@ const RADIANS_TO_DEGREES = 180 / PI;
 const TILE_SIZE = 512;
 // Average circumference (40075 km equatorial, 40007 km meridional)
 const EARTH_CIRCUMFERENCE = 40.03e6;
+// Latitude that makes a square world, 2 * atan(E ** PI) - PI / 2
+export const MAX_LATITUDE = 85.051129;
 
 // Mapbox default altitude
 export const DEFAULT_ALTITUDE = 1.5;

--- a/modules/web-mercator/test/spec/fit-bounds.spec.js
+++ b/modules/web-mercator/test/spec/fit-bounds.spec.js
@@ -98,9 +98,25 @@ const FITBOUNDS_TEST_CASES =
         offset: [0, -40]
       },
       {
-        longitude: -23.406499999999973,
-        latitude: 64.870857602,
-        zoom: 12.476957831
+        longitude: -23.406499999999998,
+        latitude: 64.86614331652771,
+        zoom: 12.476957831451607
+      }
+    ],
+    [
+      {
+        width: 512,
+        height: 512,
+        // southwest bound first
+        bounds: [
+          [-180, -90],
+          [180, 90]
+        ]
+      },
+      {
+        longitude: 0,
+        latitude: 0,
+        zoom: 0
       }
     ]
   ]);

--- a/modules/web-mercator/test/spec/fly-to-viewport.spec.js
+++ b/modules/web-mercator/test/spec/fly-to-viewport.spec.js
@@ -101,7 +101,7 @@ const DURATION_TEST_CASES = [
 test('flyToViewport', (t) => {
   FLY_TO_TEST_CASES.forEach((testCase) => {
     const propsInTransition = flyToViewport(testCase.startProps, testCase.endProps, testCase.t);
-    t.deepEqual(toLowPrecision(propsInTransition, 7), testCase.expect, 'interpolated correctly');
+    t.deepEqual(toLowPrecision(propsInTransition), testCase.expect, 'interpolated correctly');
   });
 
   t.end();
@@ -111,8 +111,8 @@ test('getFlyToDuration', (t) => {
   DURATION_TEST_CASES.forEach((testCase) => {
     const duration = getFlyToDuration(testCase.startProps, testCase.endProps, testCase.opts);
     t.deepEqual(
-      toLowPrecision(duration, 8),
-      testCase.expect,
+      toLowPrecision(duration),
+      toLowPrecision(testCase.expect),
       `${testCase.title}: should get correct duration`
     );
   });

--- a/modules/web-mercator/test/utils/test-utils.js
+++ b/modules/web-mercator/test/utils/test-utils.js
@@ -5,10 +5,11 @@
  * @param  {Number} [precision] Desired precision
  * @return {any}            Input data, with all numbers converted
  */
-export function toLowPrecision(input, precision = 11) {
+export function toLowPrecision(input, precision = 7) {
   /* eslint-disable guard-for-in */
   if (typeof input === 'number') {
-    input = Number(input.toPrecision(precision));
+    input =
+      Math.abs(input) > 1 ? Number(input.toPrecision(precision)) : Number(input.toFixed(precision));
   } else if (Array.isArray(input)) {
     input = input.map((item) => toLowPrecision(item, precision));
   } else if (ArrayBuffer.isView(input)) {


### PR DESCRIPTION
Fix `fitBounds` crash when bounds contain extreme latitudes. (trying to unproject `Infinity`)