### PR TITLE
Add unitsPerMeter util

### DIFF
--- a/modules/web-mercator/src/index.ts
+++ b/modules/web-mercator/src/index.ts
@@ -18,6 +18,7 @@ export {
   altitudeToFovy,
   fovyToAltitude,
   getMeterZoom,
+  unitsPerMeter,
   getDistanceScales,
   addMetersToLngLat,
   getViewMatrix,

--- a/modules/web-mercator/src/web-mercator-utils.ts
+++ b/modules/web-mercator/src/web-mercator-utils.ts
@@ -108,6 +108,17 @@ export function getMeterZoom(options: {latitude: number}): number {
 }
 
 /**
+ * Calculate the conversion from meter to common units at a given latitude
+ * This is a cheaper version of `getDistanceScales`
+ * @param latitude center latitude in degrees
+ * @returns common units per meter
+ */
+export function unitsPerMeter(latitude: number): number {
+  const latCosine = Math.cos(latitude * DEGREES_TO_RADIANS);
+  return TILE_SIZE / EARTH_CIRCUMFERENCE / latCosine;
+}
+
+/**
  * Calculate distance scales in meters around current lat/lon, both for
  * degrees and pixels.
  * In mercator projection mode, the distance scales vary significantly


### PR DESCRIPTION
A more efficient function to replace

`getDistanceScales({longitude, latitude}).unitsPerMeter`

Moving here from deck's WebMercatorViewport