### PR TITLE
[polygon] Add plane option to earcut

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -33,9 +33,13 @@ Codebase has been fully converted to typescript. In general this means that user
 the types exported from math.gl to be considerably improved, however in some function signatures
 are no longer supported. For details, consult the [upgrade guide](./upgrade-guide).
 
-**`@math.gl/types` (NEW)
+**`@math.gl/types` (NEW)**
 
 - New module that exports a few typescript types that e.g. generalize handling of numeric arrays.
+
+**`@math.gl/polygon` (NEW)**
+- Includes earcut 2.2 (various bug fixes for edge cases)
+- The `earcut` utility supports a new argument `plane` to calculate tesselation on alternative projection planes.
 
 ## v3.5
 

--- a/modules/polygon/docs/api-reference/earcut.md
+++ b/modules/polygon/docs/api-reference/earcut.md
@@ -20,7 +20,7 @@ earcut([0, 0, 100, 0, 100, 100, 0, 100, 20, 20, 80, 20, 80, 80, 20, 80], [4]);
 ## Usage
 
 ```js
-earcut(positions[, holeIndices, size = 2, areas]);
+earcut(positions[, holeIndices, size = 2, areas, plane]);
 ```
 
 Arguments:
@@ -29,6 +29,7 @@ Arguments:
 - `holeIndices` (Array, optional) - is an array of hole indices if any (e.g. [5, 8] for a 12-vertex input would mean one hole with vertices 5–7 and another with 8–11).
 - `size` (Number, optional) - the number of elements in each vertex. Size `2` will interpret `positions` as `[x0, y0, x1, y1, ...]` and size `3` will interpret `positions` as `[x0, y0, z0, x1, y1, z1, ...]`. Default `2`.
 - `areas` (Array, optional) - areas of outer polygon and holes as computed by `getPolygonSignedArea()`. Can be optionally supplied to speed up triangulation
+- `plane` (String, optional) - the 2D projection plane on which to tesselate a 3D polygon on. One of `xy`, `yz`, `xz`. Default to `xy`
 
 Returns:
 

--- a/modules/polygon/docs/api-reference/polygon-utils.md
+++ b/modules/polygon/docs/api-reference/polygon-utils.md
@@ -43,12 +43,13 @@ Returns true if the winding direction was changed.
 
 Returns signed area of the polygon.
 
-`getPolygonSignedArea(points, options)`
+`getPolygonSignedArea(points, options, plane)`
 
 Arguments:
 
 - `points` (Array|TypedArray) - a flat array of the points that define the polygon.
-- `options` (PolygonParams) - Polygon parameters.
+- `options` (PolygonParams, optional) - Polygon parameters.
+- `plane` (String, optional) - the 2D projection plane on which to calculate the area of a 3D polygon. One of `xy`, `yz`, `xz`. Default to `xy`
 
 Returns:
 

--- a/modules/polygon/docs/api-reference/polygon-utils.md
+++ b/modules/polygon/docs/api-reference/polygon-utils.md
@@ -20,6 +20,7 @@ Fields:
 - `end` (number) - End index of the polygon in the array of positions. Defaults to number of positions.
 - `size` (Number) - Size of a point, 2 (XZ) or 3 (XYZ). Defaults to 2. Affects only polygons stored in flat arrays.
 - `isClosed` (Boolean) - Indicates that the first point of the polygon is equal to the last point, and additional checks should be ommited.
+- `plane` ('xy' | 'yz' | 'xz') - The 2D projection plane on which to calculate the area of a 3D polygon. Default `'xy'`.
 
 ## Functions
 
@@ -49,7 +50,6 @@ Arguments:
 
 - `points` (Array|TypedArray) - a flat array of the points that define the polygon.
 - `options` (PolygonParams, optional) - Polygon parameters.
-- `plane` (String, optional) - the 2D projection plane on which to calculate the area of a 3D polygon. One of `xy`, `yz`, `xz`. Default to `xy`
 
 Returns:
 

--- a/modules/polygon/src/earcut.ts
+++ b/modules/polygon/src/earcut.ts
@@ -99,7 +99,7 @@ function linkedList(
   let i;
   let last;
   if (area === undefined) {
-    area = getPolygonSignedArea(data, {start, end, size: dim}, plane);
+    area = getPolygonSignedArea(data, {start, end, size: dim, plane});
   }
 
   let i0 = DimIndex[plane[0]];

--- a/modules/polygon/src/polygon-utils.ts
+++ b/modules/polygon/src/polygon-utils.ts
@@ -71,6 +71,13 @@ export function getPolygonWindingDirection(
   return Math.sign(getPolygonSignedArea(points, options));
 }
 
+export type Plane2D = 'xy' | 'yz' | 'xz';
+export const DimIndex: Record<string, number> = {
+  x: 0,
+  y: 1,
+  z: 2
+} as const;
+
 /**
  * Returns signed area of the polygon.
  * @param points An array that represents points of the polygon.
@@ -78,12 +85,19 @@ export function getPolygonWindingDirection(
  * @returns Signed area of the polygon.
  * https://en.wikipedia.org/wiki/Shoelace_formula
  */
-export function getPolygonSignedArea(points: NumericArray, options: PolygonParams = {}): number {
+export function getPolygonSignedArea(
+  points: NumericArray,
+  options: PolygonParams = {},
+  plane: Plane2D = 'xy'
+): number {
   const {start = 0, end = points.length} = options;
   const dim = options.size || 2;
   let area = 0;
+  const i0 = DimIndex[plane[0]];
+  const i1 = DimIndex[plane[1]];
+
   for (let i = start, j = end - dim; i < end; i += dim) {
-    area += (points[i] - points[j]) * (points[i + 1] + points[j + 1]);
+    area += (points[i + i0] - points[j + i0]) * (points[i + i1] + points[j + i1]);
     j = i;
   }
   return area / 2;

--- a/modules/polygon/src/polygon-utils.ts
+++ b/modules/polygon/src/polygon-utils.ts
@@ -29,12 +29,34 @@ export type SegmentVisitorPoints = (
   i2: number
 ) => void;
 
+export type Plane2D = 'xy' | 'yz' | 'xz';
+
 /** Parameters of a polygon. */
 type PolygonParams = {
-  start?: number; // Start index of the polygon in the array of positions. Defaults to 0.
-  end?: number; // End index of the polygon in the array of positions. Defaults to number of positions.
-  size?: number; // Size of a point, 2 (XZ) or 3 (XYZ). Defaults to 2. Affects only polygons stored in flat arrays.
-  isClosed?: boolean; // Indicates that the first point of the polygon is equal to the last point, and additional checks should be ommited.
+  /**
+   * Start index of the polygon in the array of positions.
+   * @default `0`
+   */
+  start?: number;
+  /**
+   * End index of the polygon in the array of positions.
+   * @default number of positions
+   */
+  end?: number;
+  /**
+   * Size of a point, 2 (XZ) or 3 (XYZ). Affects only polygons stored in flat arrays.
+   * @default `2`
+   */
+  size?: number;
+  /**
+   * Indicates that the first point of the polygon is equal to the last point, and additional checks should be ommited.
+   */
+  isClosed?: boolean;
+  /**
+   * The 2D projection plane on which to calculate the area of a 3D polygon.
+   * @default `'xy'`
+   */
+  plane?: Plane2D;
 };
 
 /**
@@ -71,7 +93,6 @@ export function getPolygonWindingDirection(
   return Math.sign(getPolygonSignedArea(points, options));
 }
 
-export type Plane2D = 'xy' | 'yz' | 'xz';
 export const DimIndex: Record<string, number> = {
   x: 0,
   y: 1,
@@ -85,12 +106,8 @@ export const DimIndex: Record<string, number> = {
  * @returns Signed area of the polygon.
  * https://en.wikipedia.org/wiki/Shoelace_formula
  */
-export function getPolygonSignedArea(
-  points: NumericArray,
-  options: PolygonParams = {},
-  plane: Plane2D = 'xy'
-): number {
-  const {start = 0, end = points.length} = options;
+export function getPolygonSignedArea(points: NumericArray, options: PolygonParams = {}): number {
+  const {start = 0, end = points.length, plane = 'xy'} = options;
   const dim = options.size || 2;
   let area = 0;
   const i0 = DimIndex[plane[0]];
@@ -210,10 +227,13 @@ export function getPolygonSignedAreaPoints(
   options: PolygonParams = {}
 ): number {
   // https://en.wikipedia.org/wiki/Shoelace_formula
-  const {start = 0, end = points.length} = options;
+  const {start = 0, end = points.length, plane = 'xy'} = options;
   let area = 0;
+  const i0 = DimIndex[plane[0]];
+  const i1 = DimIndex[plane[1]];
+
   for (let i = start, j = end - 1; i < end; ++i) {
-    area += (points[i][0] - points[j][0]) * (points[i][1] + points[j][1]);
+    area += (points[i][i0] - points[j][i0]) * (points[i][i1] + points[j][i1]);
     j = i;
   }
   return area / 2;

--- a/modules/polygon/test/earcut.spec.ts
+++ b/modules/polygon/test/earcut.spec.ts
@@ -39,8 +39,19 @@ test('indices-3d', function (t) {
   t.end();
 });
 
-test('empty', function (t) {
-  t.same(earcut([]), []);
+test('indices-3d', function (t) {
+  const indices = earcut([10, 4, 0, 0, 50, 0, 60, 60, 0, 70, 10, 0], null, 3);
+  t.same(indices, [1, 0, 3, 3, 2, 1]);
+  t.end();
+});
+
+test('projection', function (t) {
+  let indices = earcut([0, 4, 0, 0, 50, 0, 0, 60, 20, 0, 10, 20], null, 3, undefined, 'xy');
+  t.same(indices, []); // Polygon has no area on the XY plane
+
+  indices = earcut([0, 4, 0, 0, 50, 0, 0, 60, 20, 0, 10, 20], null, 3, undefined, 'yz');
+  t.same(indices, [2, 3, 0, 0, 1, 2]);
+
   t.end();
 });
 


### PR DESCRIPTION
Incorporate features from https://github.com/visgl/deck.gl/pull/7205 but without mutating the positions array.

Also use permissive typing (`number[]` -> `NumericArray`) so that deck.gl can call this function directly.