### PR TITLE
chore: Remove default exports

### DIFF
--- a/modules/core/src/classes/base/math-array.ts
+++ b/modules/core/src/classes/base/math-array.ts
@@ -3,7 +3,7 @@ import {NumericArray} from '@math.gl/types';
 import {ConfigurationOptions, config, formatValue, equals, isArray} from '../../lib/common';
 
 /** Base class for vectors and matrices */
-export default abstract class MathArray extends Array<number> {
+export abstract class MathArray extends Array<number> {
   /** Number of elements (values) in this array */
   abstract get ELEMENTS(): number;
 
@@ -37,6 +37,10 @@ export default abstract class MathArray extends Array<number> {
       targetArray[offset + i] = this[i];
     }
     return targetArray;
+  }
+
+  toObject(targetObject: Record<string, unknown>): Record<string, unknown> {
+    return targetObject;
   }
 
   from(arrayOrObject: Readonly<NumericArray> | Record<string, unknown>): this {

--- a/modules/core/src/classes/base/matrix.ts
+++ b/modules/core/src/classes/base/matrix.ts
@@ -1,12 +1,12 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // MIT License
 import {NumericArray} from '@math.gl/types';
-import MathArray from './math-array';
+import {MathArray} from './math-array';
 import {checkNumber} from '../../lib/validators';
 import {config} from '../../lib/common';
 
 /** Base class for matrices */
-export default abstract class Matrix extends MathArray {
+export abstract class Matrix extends MathArray {
   abstract get RANK(): number;
 
   // fromObject(object) {

--- a/modules/core/src/classes/base/vector.ts
+++ b/modules/core/src/classes/base/vector.ts
@@ -1,12 +1,12 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // MIT License
 import {NumericArray} from '@math.gl/types';
-import MathArray from './math-array';
+import {MathArray} from './math-array';
 import {checkNumber} from '../../lib/validators';
-import assert from '../../lib/assert';
+import {assert} from '../../lib/assert';
 
 /** Base class for vectors with at least 2 elements */
-export default abstract class Vector extends MathArray {
+export abstract class Vector extends MathArray {
   // ACCESSORS
 
   get x(): number {

--- a/modules/core/src/classes/euler.ts
+++ b/modules/core/src/classes/euler.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // MIT License
-import MathArray from './base/math-array';
-import Quaternion from './quaternion';
+import {MathArray} from './base/math-array';
+import {Quaternion} from './quaternion';
 import {NumericArray} from '@math.gl/types';
 
 import {clamp} from '../lib/common';
@@ -20,7 +20,7 @@ enum RotationOrder {
   XYZ = 5
 }
 
-export default class Euler extends MathArray {
+export class Euler extends MathArray {
   // Constants
   static get ZYX(): RotationOrder {
     return RotationOrder.ZYX;

--- a/modules/core/src/classes/matrix3.ts
+++ b/modules/core/src/classes/matrix3.ts
@@ -2,7 +2,7 @@
 // MIT License
 
 import {NumericArray} from '@math.gl/types';
-import Matrix from './base/matrix';
+import {Matrix} from './base/matrix';
 import {checkVector} from '../lib/validators';
 /* eslint-disable camelcase */
 import {vec4_transformMat3} from '../lib/gl-matrix-extras';
@@ -27,7 +27,7 @@ enum INDICES {
 
 const IDENTITY_MATRIX = Object.freeze([1, 0, 0, 0, 1, 0, 0, 0, 1]);
 
-export default class Matrix3 extends Matrix {
+export class Matrix3 extends Matrix {
   static get IDENTITY(): Readonly<Matrix3> {
     return getIdentityMatrix();
   }

--- a/modules/core/src/classes/matrix4.ts
+++ b/modules/core/src/classes/matrix4.ts
@@ -2,7 +2,7 @@
 // MIT License
 
 import {NumericArray} from '@math.gl/types';
-import Matrix from './base/matrix';
+import {Matrix} from './base/matrix';
 import {checkVector} from '../lib/validators';
 
 /* eslint-disable camelcase */
@@ -43,7 +43,7 @@ const DEFAULT_FAR = 500;
 const IDENTITY_MATRIX = Object.freeze([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
 
 /** 4x4 matrix */
-export default class Matrix4 extends Matrix {
+export class Matrix4 extends Matrix {
   static get IDENTITY(): Readonly<Matrix4> {
     return getIdentityMatrix();
   }

--- a/modules/core/src/classes/pose.ts
+++ b/modules/core/src/classes/pose.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // MIT License
-import Matrix4 from './matrix4';
-import Vector3 from './vector3';
-import Euler from './euler';
+import {Matrix4} from './matrix4';
+import {Vector3} from './vector3';
+import {Euler} from './euler';
 import {NumericArray} from '@math.gl/types';
 
 type PoseOptions = {
@@ -16,7 +16,7 @@ type PoseOptions = {
   yaw?: number;
 };
 
-export default class Pose {
+export class Pose {
   readonly position: Vector3;
   readonly orientation: Euler;
 

--- a/modules/core/src/classes/quaternion.ts
+++ b/modules/core/src/classes/quaternion.ts
@@ -1,9 +1,9 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // MIT License
 import {NumericArray} from '@math.gl/types';
-import MathArray from './base/math-array';
+import {MathArray} from './base/math-array';
 import {checkNumber, checkVector} from '../lib/validators';
-import Vector4 from './vector4';
+import {Vector4} from './vector4';
 // @ts-ignore gl-matrix types...
 import * as quat from 'gl-matrix/quat';
 // @ts-ignore gl-matrix types...
@@ -11,7 +11,7 @@ import * as vec4 from 'gl-matrix/vec4';
 
 const IDENTITY_QUATERNION = [0, 0, 0, 1] as const;
 
-export default class Quaternion extends MathArray {
+export class Quaternion extends MathArray {
   constructor(x: number | Readonly<NumericArray> = 0, y = 0, z = 0, w = 1) {
     // PERF NOTE: initialize elements as double precision numbers
     super(-0, -0, -0, -0);

--- a/modules/core/src/classes/spherical-coordinates.ts
+++ b/modules/core/src/classes/spherical-coordinates.ts
@@ -2,7 +2,7 @@
 // MIT License
 // Adaptation of THREE.js Spherical class, under MIT license
 import {NumericArray} from '@math.gl/types';
-import Vector3 from './vector3';
+import {Vector3} from './vector3';
 import {formatValue, equals, config} from '../lib/common';
 import {degrees, radians, clamp} from '../lib/common';
 // @ts-ignore gl-matrix types...
@@ -31,7 +31,7 @@ const EARTH_RADIUS_METERS = 6371000;
  * The equator starts at positive z.
  * @link https://en.wikipedia.org/wiki/Spherical_coordinate_system
  */
-export default class SphericalCoordinates {
+export class SphericalCoordinates {
   phi: number;
   theta: number;
   radius: number;

--- a/modules/core/src/classes/vector2.ts
+++ b/modules/core/src/classes/vector2.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // MIT License
-import Vector from './base/vector';
+import {Vector} from './base/vector';
 import {config, isArray} from '../lib/common';
 import {checkNumber} from '../lib/validators';
 // @ts-ignore gl-matrix types...
@@ -13,7 +13,7 @@ import {NumericArray} from '@math.gl/types';
  * Two-element vector class.
  * Subclass of Array<number>
  */
-export default class Vector2 extends Vector {
+export class Vector2 extends Vector {
   // Creates a new, empty vec2
   constructor(x: number | Readonly<NumericArray> = 0, y: number = 0) {
     // PERF NOTE: initialize elements as double precision numbers
@@ -52,7 +52,7 @@ export default class Vector2 extends Vector {
     return this.check();
   }
 
-  toObject(object: {x?: number; y?: number}): {x: number; y: number} {
+  override toObject(object: {x?: number; y?: number}): {x: number; y: number} {
     object.x = this[0];
     object.y = this[1];
     return object as {x: number; y: number};

--- a/modules/core/src/classes/vector3.ts
+++ b/modules/core/src/classes/vector3.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // MIT License
 import {NumericArray} from '@math.gl/types';
-import Vector from './base/vector';
+import {Vector} from './base/vector';
 import {config, isArray} from '../lib/common';
 import {checkNumber} from '../lib/validators';
 // @ts-ignore gl-matrix types
@@ -17,7 +17,7 @@ let ZERO: Vector3;
  * Three-element vector class.
  * Subclass of Array<number>
  */
-export default class Vector3 extends Vector {
+export class Vector3 extends Vector {
   static get ZERO(): Vector3 {
     if (!ZERO) {
       ZERO = new Vector3(0, 0, 0);
@@ -77,7 +77,11 @@ export default class Vector3 extends Vector {
     return this.check();
   }
 
-  toObject(object: {x?: number; y?: number; z?: number}): {x: number; y: number; z: number} {
+  override toObject(object: {x?: number; y?: number; z?: number}): {
+    x: number;
+    y: number;
+    z: number;
+  } {
     object.x = this[0];
     object.y = this[1];
     object.z = this[2];

--- a/modules/core/src/classes/vector4.ts
+++ b/modules/core/src/classes/vector4.ts
@@ -7,11 +7,11 @@ import * as vec4 from 'gl-matrix/vec3';
 /* eslint-disable camelcase */
 import {vec4_transformMat2, vec4_transformMat3} from '../lib/gl-matrix-extras';
 
-import Vector from './base/vector';
+import {Vector} from './base/vector';
 import {config, isArray} from '../lib/common';
 import {checkNumber} from '../lib/validators';
 
-import type Matrix4 from './matrix4';
+import type {Matrix4} from './matrix4';
 
 let ZERO: Vector4;
 
@@ -19,7 +19,7 @@ let ZERO: Vector4;
  * Four-element vector class.
  * Subclass of Array<number>
  */
-export default class Vector4 extends Vector {
+export class Vector4 extends Vector {
   static get ZERO(): Vector4 {
     if (!ZERO) {
       ZERO = new Vector4(0, 0, 0, 0);
@@ -78,7 +78,7 @@ export default class Vector4 extends Vector {
     return this;
   }
 
-  toObject(object: {x?: number; y?: number; z?: number; w?: number}): {
+  override toObject(object: {x?: number; y?: number; z?: number; w?: number}): {
     x: number;
     y: number;
     z: number;

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -6,22 +6,22 @@ export type {TypedArray, NumericArray} from '@math.gl/types';
 export type {isTypedArray, isNumericArray} from '@math.gl/types';
 
 // classes
-export {default as Vector2} from './classes/vector2';
-export {default as Vector3} from './classes/vector3';
-export {default as Vector4} from './classes/vector4';
-export {default as Matrix3} from './classes/matrix3';
-export {default as Matrix4} from './classes/matrix4';
-export {default as Quaternion} from './classes/quaternion';
+export {Vector2} from './classes/vector2';
+export {Vector3} from './classes/vector3';
+export {Vector4} from './classes/vector4';
+export {Matrix3} from './classes/matrix3';
+export {Matrix4} from './classes/matrix4';
+export {Quaternion} from './classes/quaternion';
 
 // experimental
-export {default as SphericalCoordinates} from './classes/spherical-coordinates';
-export {default as Pose} from './classes/pose';
-export {default as Euler} from './classes/euler';
+export {SphericalCoordinates} from './classes/spherical-coordinates';
+export {Pose} from './classes/pose';
+export {Euler} from './classes/euler';
 
-export {default as _MathUtils} from './lib/math-utils';
+export * as _MathUtils from './lib/math-utils';
 
 // lib
-export {default as assert} from './lib/assert';
+export {assert} from './lib/assert';
 
 export {
   // math.gl global utility methods
@@ -49,6 +49,6 @@ export {
 } from './lib/common';
 
 // DEPRECATED
-export {default as _SphericalCoordinates} from './classes/spherical-coordinates';
-export {default as _Pose} from './classes/pose';
-export {default as _Euler} from './classes/euler';
+export {SphericalCoordinates as _SphericalCoordinates} from './classes/spherical-coordinates';
+export {Pose as _Pose} from './classes/pose';
+export {Euler as _Euler} from './classes/euler';

--- a/modules/core/src/lib/assert.ts
+++ b/modules/core/src/lib/assert.ts
@@ -1,4 +1,4 @@
-export default function assert(condition: unknown, message?: string): void {
+export function assert(condition: unknown, message?: string): void {
   if (!condition) {
     throw new Error(`math.gl assertion ${message}`);
   }

--- a/modules/core/src/lib/common.ts
+++ b/modules/core/src/lib/common.ts
@@ -2,7 +2,7 @@
 
 import type {NumericArray} from '@math.gl/types';
 
-import type MathArray from '../classes/base/math-array';
+import type {MathArray} from '../classes/base/math-array';
 
 const RADIANS_TO_DEGREES = (1 / Math.PI) * 180;
 const DEGREES_TO_RADIANS = (1 / 180) * Math.PI;

--- a/modules/core/src/lib/math-utils.ts
+++ b/modules/core/src/lib/math-utils.ts
@@ -1,30 +1,28 @@
 // NOTE: Added to make Cesium-derived test cases work
 // TODO: Determine if/how to keep
-export default {
-  EPSILON1: 1e-1,
-  EPSILON2: 1e-2,
-  EPSILON3: 1e-3,
-  EPSILON4: 1e-4,
-  EPSILON5: 1e-5,
-  EPSILON6: 1e-6,
-  EPSILON7: 1e-7,
-  EPSILON8: 1e-8,
-  EPSILON9: 1e-9,
-  EPSILON10: 1e-10,
-  EPSILON11: 1e-11,
-  EPSILON12: 1e-12,
-  EPSILON13: 1e-13,
-  EPSILON14: 1e-14,
-  EPSILON15: 1e-15,
-  EPSILON16: 1e-16,
-  EPSILON17: 1e-17,
-  EPSILON18: 1e-18,
-  EPSILON19: 1e-19,
-  EPSILON20: 1e-20,
+export const EPSILON1 = 1e-1;
+export const EPSILON2 = 1e-2;
+export const EPSILON3 = 1e-3;
+export const EPSILON4 = 1e-4;
+export const EPSILON5 = 1e-5;
+export const EPSILON6 = 1e-6;
+export const EPSILON7 = 1e-7;
+export const EPSILON8 = 1e-8;
+export const EPSILON9 = 1e-9;
+export const EPSILON10 = 1e-10;
+export const EPSILON11 = 1e-11;
+export const EPSILON12 = 1e-12;
+export const EPSILON13 = 1e-13;
+export const EPSILON14 = 1e-14;
+export const EPSILON15 = 1e-15;
+export const EPSILON16 = 1e-16;
+export const EPSILON17 = 1e-17;
+export const EPSILON18 = 1e-18;
+export const EPSILON19 = 1e-19;
+export const EPSILON20 = 1e-20;
 
-  PI_OVER_TWO: Math.PI / 2,
-  PI_OVER_FOUR: Math.PI / 4,
-  PI_OVER_SIX: Math.PI / 6,
+export const PI_OVER_TWO = Math.PI / 2;
+export const PI_OVER_FOUR = Math.PI / 4;
+export const PI_OVER_SIX = Math.PI / 6;
 
-  TWO_PI: Math.PI * 2
-};
+export const TWO_PI = Math.PI * 2;

--- a/modules/core/test/bench.ts
+++ b/modules/core/test/bench.ts
@@ -27,7 +27,7 @@ import vector3Bench from './classes/vector3.bench';
 import vector4Bench from './classes/vector4.bench';
 import matrix4Bench from './classes/matrix4.bench';
 
-export default function coreBench(suite, addReferenceBenchmarks) {
+export function coreBench(suite, addReferenceBenchmarks) {
   // classesBench(suite, addReferenceBenchmarks);
   commonBench(suite, addReferenceBenchmarks);
   javascriptBench(suite, addReferenceBenchmarks);

--- a/modules/core/test/classes/classes.bench.ts
+++ b/modules/core/test/classes/classes.bench.ts
@@ -25,7 +25,7 @@ configure({debug: false});
 const mathglArray = new Matrix4();
 const mathglVector4 = new Vector4();
 
-export default function classesBench(suite, addReferenceBenchmarks) {
+export function classesBench(suite, addReferenceBenchmarks) {
   suite
     // add tests
     .group('@math.gl/core: Object Construction Summary')

--- a/modules/core/test/classes/matrix4.bench.ts
+++ b/modules/core/test/classes/matrix4.bench.ts
@@ -69,7 +69,7 @@ const dirVector4 = new Vector4(0, 0, 0, 0);
 const pointVector4 = new Vector4(0, 0, 0, 1);
 const vector3 = [0, 0, 0];
 
-export default function matrix4Bench(suite, addReferenceBenchmarks) {
+export function matrix4Bench(suite, addReferenceBenchmarks) {
   suite
     // add tests
     .group('@math.gl/core: Matrix4 constructors')

--- a/modules/core/test/classes/vector2.bench.ts
+++ b/modules/core/test/classes/vector2.bench.ts
@@ -24,7 +24,7 @@ const array = [0, 0];
 const float32Array = new Float32Array([0, 0]);
 const vector2 = new Vector2();
 
-export default function vector2Bench(suite, addReferenceBenchmarks) {
+export function vector2Bench(suite, addReferenceBenchmarks) {
   suite
     .group('@math.gl/core: Vector2')
     .add('Vector2#new()', () => new Vector2(1, 2))

--- a/modules/core/test/classes/vector3.bench.ts
+++ b/modules/core/test/classes/vector3.bench.ts
@@ -38,7 +38,7 @@ const objectVector = new ObjectVector();
 const arrayVector = new Vector3();
 const vector3 = new Vector3();
 
-export default function vector3Bench(suite, addReferenceBenchmarks) {
+export function vector3Bench(suite, addReferenceBenchmarks) {
   suite
     .group('@math.gl/core: Vector3')
     .add('Vector3#new()', () => new Vector3(1, 2, 3))

--- a/modules/core/test/classes/vector4.bench.ts
+++ b/modules/core/test/classes/vector4.bench.ts
@@ -24,7 +24,7 @@ const array = [0, 0, 0, 0];
 const float32Array = new Float32Array([0, 0, 0, 0]);
 const vector4 = new Vector4();
 
-export default function vector4Bench(suite, addReferenceBenchmarks) {
+export function vector4Bench(suite, addReferenceBenchmarks) {
   suite
     .group('@math.gl/core: Vector4')
     .add('Vector4#new()', () => new Vector4(1, 2, 3, 4))

--- a/modules/core/test/lib/common.bench.ts
+++ b/modules/core/test/lib/common.bench.ts
@@ -26,7 +26,7 @@ const float32Array = new Float32Array([1, 0, 0]);
 const float64Array = new Float64Array([1, 0, 0]);
 const vector3 = new Vector3();
 
-export default function commonBench(suite, addReferenceBenchmarks) {
+export function commonBench(suite, addReferenceBenchmarks) {
   suite
     .group('@math.gl/core: Global Functions')
     .add('isArray(Vector3)', () => isArray(vector3))

--- a/modules/core/test/lib/javascript.bench.ts
+++ b/modules/core/test/lib/javascript.bench.ts
@@ -90,7 +90,7 @@ class XYZVectorBitwiseOr {
 
 // COMBINED BENCH
 
-export default function javascriptBench(suite, addReferenceBenchmarks) {
+export function javascriptBench(suite, addReferenceBenchmarks) {
   if (addReferenceBenchmarks) {
     suite
       .group('Class/Array inheritance construction cost')

--- a/modules/core/test/threejs-tests/matrix3-three.spec.ts
+++ b/modules/core/test/threejs-tests/matrix3-three.spec.ts
@@ -28,8 +28,8 @@
 /* eslint-disable quotes, no-var */
 import test from 'tape-promise/tape';
 
-import Matrix3 from 'math.gl/matrix3';
-import Matrix4 from 'math.gl/matrix4';
+import {Matrix3} from 'math.gl/matrix3';
+import {Matrix4} from 'math.gl/matrix4';
 
 function matrixEquals3(a, b, tolerance) {
   tolerance = tolerance || 0.0001;

--- a/modules/culling/src/index.ts
+++ b/modules/culling/src/index.ts
@@ -3,18 +3,18 @@
 
 export {INTERSECTION} from './constants';
 
-export {default as AxisAlignedBoundingBox} from './lib/bounding-volumes/axis-aligned-bounding-box';
-export {default as BoundingSphere} from './lib/bounding-volumes/bounding-sphere';
-export {default as OrientedBoundingBox} from './lib/bounding-volumes/oriented-bounding-box';
-export {default as CullingVolume} from './lib/culling-volume';
-export {default as Plane} from './lib/plane';
+export {AxisAlignedBoundingBox} from './lib/bounding-volumes/axis-aligned-bounding-box';
+export {BoundingSphere} from './lib/bounding-volumes/bounding-sphere';
+export {OrientedBoundingBox} from './lib/bounding-volumes/oriented-bounding-box';
+export {CullingVolume} from './lib/culling-volume';
+export {Plane} from './lib/plane';
 
-export {default as _PerspectiveOffCenterFrustum} from './lib/perspective-off-center-frustum';
-export {default as _PerspectiveFrustum} from './lib/perspective-frustum';
+export {PerspectiveOffCenterFrustum as _PerspectiveOffCenterFrustum} from './lib/perspective-off-center-frustum';
+export {PerspectiveFrustum as _PerspectiveFrustum} from './lib/perspective-frustum';
 
-export {default as makeBoundingSphereFromPoints} from './lib/algorithms/bounding-sphere-from-points';
+export {makeBoundingSphereFromPoints} from './lib/algorithms/bounding-sphere-from-points';
 export {
   makeAxisAlignedBoundingBoxFromPoints,
   makeOrientedBoundingBoxFromPoints
 } from './lib/algorithms/bounding-box-from-points';
-export {default as computeEigenDecomposition} from './lib/algorithms/compute-eigen-decomposition';
+export {computeEigenDecomposition} from './lib/algorithms/compute-eigen-decomposition';

--- a/modules/culling/src/lib/algorithms/bounding-box-from-points.ts
+++ b/modules/culling/src/lib/algorithms/bounding-box-from-points.ts
@@ -2,9 +2,9 @@
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
 import {Vector3, Matrix3} from '@math.gl/core';
-import computeEigenDecomposition from './compute-eigen-decomposition';
-import OrientedBoundingBox from '../bounding-volumes/oriented-bounding-box';
-import AxisAlignedBoundingBox from '../bounding-volumes/axis-aligned-bounding-box';
+import {computeEigenDecomposition} from './compute-eigen-decomposition';
+import {OrientedBoundingBox} from '../bounding-volumes/oriented-bounding-box';
+import {AxisAlignedBoundingBox} from '../bounding-volumes/axis-aligned-bounding-box';
 
 const scratchVector2 = new Vector3();
 

--- a/modules/culling/src/lib/algorithms/bounding-sphere-from-points.ts
+++ b/modules/culling/src/lib/algorithms/bounding-sphere-from-points.ts
@@ -2,7 +2,7 @@
 // See LICENSE.md and https://github.com/AnalyticalGraphicsInc/cesium/blob/master/LICENSE.md
 
 import {Vector3} from '@math.gl/core';
-import BoundingSphere from '../bounding-volumes/bounding-sphere';
+import {BoundingSphere} from '../bounding-volumes/bounding-sphere';
 
 /* eslint-disable */
 const fromPointsXMin = new Vector3();
@@ -30,7 +30,7 @@ const fromPointsNaiveCenterScratch = new Vector3();
  * @param result Optional object onto which to store the result.
  * @returns The modified result parameter or a new `BoundingSphere` instance if not provided.
  */
-export default function makeBoundingSphereFromPoints(
+export function makeBoundingSphereFromPoints(
   positions: number[][],
   result: BoundingSphere = new BoundingSphere()
 ): BoundingSphere {

--- a/modules/culling/src/lib/algorithms/compute-eigen-decomposition.ts
+++ b/modules/culling/src/lib/algorithms/compute-eigen-decomposition.ts
@@ -45,7 +45,7 @@ export type EigenDecomposition = {
  * const v = result.unitary.getColumn(0, new Vector3());          // first eigenvector
  * const c = v.multiplyByScalar(lambda);                          // equal to v.transformByMatrix3(a)
  */
-export default function computeEigenDecomposition(
+export function computeEigenDecomposition(
   matrix: number[],
   // @ts-expect-error accept empty object type
   result: EigenDecomposition = {}

--- a/modules/culling/src/lib/bounding-volumes/axis-aligned-bounding-box.ts
+++ b/modules/culling/src/lib/bounding-volumes/axis-aligned-bounding-box.ts
@@ -1,6 +1,6 @@
 import {BoundingVolume} from './bounding-volume';
 import {Vector3} from '@math.gl/core';
-import Plane from '../plane';
+import {Plane} from '../plane';
 import {INTERSECTION} from '../../constants';
 
 const scratchVector = new Vector3();
@@ -12,7 +12,7 @@ const scratchNormal = new Vector3();
  * @see BoundingRectangle
  * @see OrientedBoundingBox
  */
-export default class AxisAlignedBoundingBox implements BoundingVolume {
+export class AxisAlignedBoundingBox implements BoundingVolume {
   /** The center point of the bounding box. */
   readonly center: Vector3;
   /** The positive half diagonal of the bounding box. */

--- a/modules/culling/src/lib/bounding-volumes/bounding-sphere.ts
+++ b/modules/culling/src/lib/bounding-volumes/bounding-sphere.ts
@@ -7,13 +7,13 @@ import * as mat4 from 'gl-matrix/mat4';
 
 import {INTERSECTION} from '../../constants';
 import {BoundingVolume} from './bounding-volume';
-import Plane from '../plane';
+import {Plane} from '../plane';
 
 const scratchVector = new Vector3();
 const scratchVector2 = new Vector3();
 
 /** A BoundingSphere */
-export default class BoundingSphere implements BoundingVolume {
+export class BoundingSphere implements BoundingVolume {
   center: Vector3;
   radius: number;
 

--- a/modules/culling/src/lib/bounding-volumes/bounding-volume.ts
+++ b/modules/culling/src/lib/bounding-volumes/bounding-volume.ts
@@ -1,5 +1,5 @@
 // import {INTERSECTION} from '../../constants';
-import Plane from '../plane';
+import {Plane} from '../plane';
 
 /**
  * Common interface for BoundingVolumes

--- a/modules/culling/src/lib/bounding-volumes/oriented-bounding-box.ts
+++ b/modules/culling/src/lib/bounding-volumes/oriented-bounding-box.ts
@@ -3,8 +3,8 @@
 
 import {Vector3, Matrix3, Matrix4, Quaternion, NumericArray} from '@math.gl/core';
 import type {BoundingVolume} from './bounding-volume';
-import BoundingSphere from './bounding-sphere';
-import type Plane from '../plane';
+import {BoundingSphere} from './bounding-sphere';
+import type {Plane} from '../plane';
 import {INTERSECTION} from '../../constants';
 
 const scratchVector3 = new Vector3();
@@ -32,7 +32,7 @@ const MATRIX3 = {
  * It can provide a tighter bounding volume than `BoundingSphere` or
  * `AxisAlignedBoundingBox` in many cases.
  */
-export default class OrientedBoundingBox implements BoundingVolume {
+export class OrientedBoundingBox implements BoundingVolume {
   center: Vector3;
   halfAxes: Matrix3;
 

--- a/modules/culling/src/lib/culling-volume.ts
+++ b/modules/culling/src/lib/culling-volume.ts
@@ -4,9 +4,9 @@
 /* eslint-disable */
 import {Vector3, assert} from '@math.gl/core';
 import {INTERSECTION} from '../constants';
-import Plane from './plane';
+import {Plane} from './plane';
 import type {BoundingVolume} from './bounding-volumes/bounding-volume';
-import type BoundingSphere from './bounding-volumes/bounding-sphere';
+import type {BoundingSphere} from './bounding-volumes/bounding-sphere';
 
 // X, Y, Z Unit vectors
 const faces = [new Vector3([1, 0, 0]), new Vector3([0, 1, 0]), new Vector3([0, 0, 1])];
@@ -16,7 +16,7 @@ const scratchPlaneNormal = new Vector3();
 // const scratchPlane = new Plane(new Vector3(1.0, 0.0, 0.0), 0.0);
 
 /** A culling volume defined by planes. */
-export default class CullingVolume {
+export class CullingVolume {
   /**
    * For plane masks (as used in {@link CullingVolume#computeVisibilityWithPlaneMask}), this special value
    * represents the case where the object bounding volume is entirely outside the culling volume.

--- a/modules/culling/src/lib/perspective-frustum.ts
+++ b/modules/culling/src/lib/perspective-frustum.ts
@@ -6,8 +6,8 @@
 // - Documentation has not been ported
 
 import {assert, Matrix4, NumericArray, Vector2} from '@math.gl/core';
-import PerspectiveOffCenterFrustum from './perspective-off-center-frustum';
-import CullingVolume from './culling-volume';
+import {PerspectiveOffCenterFrustum} from './perspective-off-center-frustum';
+import {CullingVolume} from './culling-volume';
 
 const defined = (val: unknown) => val !== null && typeof val !== 'undefined';
 
@@ -44,7 +44,7 @@ type PerspectiveFrustumOptions = {
  *
  * @see PerspectiveOffCenterFrustum
  */
-export default class PerspectiveFrustum {
+export class PerspectiveFrustum {
   private _offCenterFrustum = new PerspectiveOffCenterFrustum();
   /**
    * The angle of the field of view (FOV), in radians.  This angle will be used

--- a/modules/culling/src/lib/perspective-off-center-frustum.ts
+++ b/modules/culling/src/lib/perspective-off-center-frustum.ts
@@ -6,8 +6,8 @@
 // - Documentation has not been ported
 
 import {Vector3, Vector2, Matrix4, assert, NumericArray} from '@math.gl/core';
-import CullingVolume from './culling-volume';
-import Plane from './plane';
+import {CullingVolume} from './culling-volume';
+import {Plane} from './plane';
 
 const scratchPlaneUpVector = new Vector3();
 const scratchPlaneRightVector = new Vector3();
@@ -24,7 +24,7 @@ type PerspectiveOffCenterFrustumOptions = {
   far?: number;
 };
 
-export default class PerspectiveOffCenterFrustum {
+export class PerspectiveOffCenterFrustum {
   /**
    * Defines the left clipping plane.
    * @type {Number}

--- a/modules/culling/src/lib/plane.ts
+++ b/modules/culling/src/lib/plane.ts
@@ -8,7 +8,7 @@ const scratchPosition = new Vector3();
 const scratchNormal = new Vector3();
 
 // A plane in Hessian Normal Form
-export default class Plane {
+export class Plane {
   readonly normal: Vector3;
   distance: number;
 

--- a/modules/culling/test/bench.ts
+++ b/modules/culling/test/bench.ts
@@ -9,7 +9,7 @@ const boundingSphere = new BoundingSphere();
 const transform = new Matrix4();
 
 // eslint-disable-next-line
-export default function cullingBench(suite, addReferenceBenchmarks) {
+export function cullingBench(suite, addReferenceBenchmarks) {
   suite
     .group('BoundingSphere')
     .add('BoundingSphere#new()', () => new BoundingSphere())

--- a/modules/geoid/src/geoid.ts
+++ b/modules/geoid/src/geoid.ts
@@ -96,7 +96,7 @@ export type GeoidProps = {
  *
  * The implementation is ported from GeographicLib-1.50.1
  */
-export default class Geoid {
+export class Geoid {
   private _v00: number = 0;
   private _v01: number = 0;
   private _v10: number = 0;

--- a/modules/geoid/src/index.ts
+++ b/modules/geoid/src/index.ts
@@ -1,2 +1,2 @@
 export {parsePGM} from './parse-pgm';
-export {default as Geoid} from './geoid';
+export {Geoid} from './geoid';

--- a/modules/geoid/src/parse-pgm.ts
+++ b/modules/geoid/src/parse-pgm.ts
@@ -4,7 +4,7 @@
 // Copyright (c) Charles Karney (2009-2018) <charles@karney.com> and licensed
 // under the MIT/X11 License.
 
-import Geoid from './geoid';
+import {Geoid} from './geoid';
 
 const ENDL = 10;
 const PIXEL_MAX = 65535;

--- a/modules/geospatial/src/ellipsoid/ellipsoid.ts
+++ b/modules/geospatial/src/ellipsoid/ellipsoid.ts
@@ -10,8 +10,8 @@ import {WGS84_RADIUS_X, WGS84_RADIUS_Y, WGS84_RADIUS_Z} from '../constants';
 import {fromCartographicToRadians, toCartographicFromRadians} from '../type-utils';
 
 import type {AxisDirection} from './helpers/ellipsoid-transform';
-import localFrameToFixedFrame from './helpers/ellipsoid-transform';
-import scaleToGeodeticSurface from './helpers/scale-to-geodetic-surface';
+import {localFrameToFixedFrame} from './helpers/ellipsoid-transform';
+import {scaleToGeodeticSurface} from './helpers/scale-to-geodetic-surface';
 
 const scratchVector = new Vector3();
 const scratchNormal = new Vector3();
@@ -25,7 +25,7 @@ const scratchCartesian = new Vector3();
  * `(x / a)^2 + (y / b)^2 + (z / c)^2 = 1`.  Primarily used
  * to represent the shape of planetary bodies.
  */
-export default class Ellipsoid {
+export class Ellipsoid {
   /** An Ellipsoid instance initialized to the WGS84 standard. */
   static readonly WGS84: Ellipsoid = new Ellipsoid(WGS84_RADIUS_X, WGS84_RADIUS_Y, WGS84_RADIUS_Z);
 

--- a/modules/geospatial/src/ellipsoid/helpers/ellipsoid-transform.ts
+++ b/modules/geospatial/src/ellipsoid/helpers/ellipsoid-transform.ts
@@ -1,6 +1,6 @@
 import {NumericArray, Vector3, assert, equals as equalsEpsilon} from '@math.gl/core';
 
-import type Ellipsoid from '../ellipsoid';
+import type {Ellipsoid} from '../ellipsoid';
 
 const EPSILON14 = 1e-14;
 
@@ -76,7 +76,7 @@ const scratchVector3 = new Vector3();
 // Computes a 4x4 transformation matrix from a reference frame
 // centered at the provided origin to the provided ellipsoid's fixed reference frame.
 // eslint-disable-next-line max-statements, max-params, complexity
-export default function localFrameToFixedFrame(
+export function localFrameToFixedFrame(
   ellipsoid: Ellipsoid,
   firstAxis: AxisDirection,
   secondAxis: AxisDirection,

--- a/modules/geospatial/src/ellipsoid/helpers/scale-to-geodetic-surface.ts
+++ b/modules/geospatial/src/ellipsoid/helpers/scale-to-geodetic-surface.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import {Vector3, _MathUtils} from '@math.gl/core';
-import type Ellipsoid from '../ellipsoid';
+import type {Ellipsoid} from '../ellipsoid';
 
 const scratchVector = new Vector3();
 const scaleToGeodeticSurfaceIntersection = new Vector3();
@@ -9,7 +9,7 @@ const scaleToGeodeticSurfaceGradient = new Vector3();
 // Scales the provided Cartesian position along the geodetic surface normal
 // so that it is on the surface of this ellipsoid.  If the position is
 // at the center of the ellipsoid, this function returns undefined.
-export default function scaleToGeodeticSurface(
+export function scaleToGeodeticSurface(
   cartesian: number[],
   ellipsoid: Ellipsoid,
   result: number[] = []

--- a/modules/geospatial/src/index.ts
+++ b/modules/geospatial/src/index.ts
@@ -1,2 +1,2 @@
-export {default as Ellipsoid} from './ellipsoid/ellipsoid';
+export {Ellipsoid} from './ellipsoid/ellipsoid';
 export {isWGS84} from './type-utils';

--- a/modules/geospatial/test/bench.ts
+++ b/modules/geospatial/test/bench.ts
@@ -31,7 +31,7 @@ const objectVector = new ObjectVector();
 const vector = new Vector3();
 const vector3 = new Vector3();
 
-export default function geospatialBench(suite: Bench, addReferenceBenchmarks?: boolean): Bench {
+export function geospatialBench(suite: Bench, addReferenceBenchmarks?: boolean): Bench {
   suite
     .group('Cartographic Type Conversion Cost')
     .add('fromCartographic#Vector3', () => fromCartographic(vector3, vector))

--- a/modules/geospatial/test/ellipsoid/ellipsoid.bench.ts
+++ b/modules/geospatial/test/ellipsoid/ellipsoid.bench.ts
@@ -18,7 +18,7 @@ const origin = new Vector3(1.0, 0.0, 0.0);
 // const northPole = new Vector3(0.0, 0.0, 1.0);
 const resultMatrix = new Matrix4();
 
-export default function ellipsoidBench(suite) {
+export function ellipsoidBench(suite) {
   // const spaceCartesian = new Vector3(4582719.8827300891, -4582719.8827300882, 1725510.4250797231);
 
   suite

--- a/modules/polygon/src/index.ts
+++ b/modules/polygon/src/index.ts
@@ -1,4 +1,4 @@
-export {default as Polygon} from './polygon';
+export {Polygon} from './polygon';
 
 export {
   getPolygonSignedArea,
@@ -16,5 +16,5 @@ export {cutPolygonByGrid, cutPolylineByGrid} from './cut-by-grid';
 
 export {cutPolylineByMercatorBounds, cutPolygonByMercatorBounds} from './cut-by-mercator-bounds';
 
-// DEPRECATED
-export {default as _Polygon} from './polygon';
+/** @deprecated */
+export {Polygon as _Polygon} from './polygon';

--- a/modules/polygon/src/polygon.ts
+++ b/modules/polygon/src/polygon.ts
@@ -19,7 +19,7 @@ export type PolygonOptions = {
   isClosed?: boolean;
 };
 
-export default class Polygon {
+export class Polygon {
   points: NumericArray | number[][];
   isFlatArray: boolean;
   options: PolygonOptions;

--- a/modules/polygon/test/bench.ts
+++ b/modules/polygon/test/bench.ts
@@ -20,7 +20,7 @@ function nextWinding() {
   return winding;
 }
 
-export default function polygonBench(suite, addReferenceBenchmarks) {
+export function polygonBench(suite, addReferenceBenchmarks) {
   suite
     .group('Polygon')
     .add('Polygon#new()', () => new Polygon(polygonSmall))

--- a/modules/proj4/test/lib/proj4-projection.spec.ts
+++ b/modules/proj4/test/lib/proj4-projection.spec.ts
@@ -7,7 +7,7 @@ import {Proj4Projection} from '@math.gl/proj4';
 import {_MathUtils} from '@math.gl/core';
 import {tapeEqualsEpsilon} from 'test/utils/tape-assertions';
 
-import testPoints from './test-data';
+import {testPoints} from './test-data';
 
 // You can do this in the grunt config for each mocha task, see the `options` config
 // Start the main app logic.

--- a/modules/proj4/test/lib/test-data.ts
+++ b/modules/proj4/test/lib/test-data.ts
@@ -1,7 +1,7 @@
 // This file is derived from  https://github.com/proj4js
 // under this permissive license: https://github.com/proj4js/proj4js/blob/master/LICENSE.md
 
-export default [
+export const testPoints = [
   {
     code: 'testmerc',
     xy: [-45007.0787624, 4151725.59875],

--- a/modules/web-mercator/src/assert.ts
+++ b/modules/web-mercator/src/assert.ts
@@ -1,7 +1,7 @@
 // Replacement for the external assert method to reduce bundle size
 // Note: We don't use the second "message" argument in calling code,
 // so no need to support it here
-export default function assert(condition: unknown, message?: string): void {
+export function assert(condition: unknown, message?: string): void {
   if (!condition) {
     throw new Error(message || '@math.gl/web-mercator: assertion failed.');
   }

--- a/modules/web-mercator/src/fit-bounds.ts
+++ b/modules/web-mercator/src/fit-bounds.ts
@@ -1,4 +1,4 @@
-import assert from './assert';
+import {assert} from './assert';
 import {log2, clamp} from './math-utils';
 import {MAX_LATITUDE, lngLatToWorld, worldToLngLat} from './web-mercator-utils';
 
@@ -53,7 +53,7 @@ type ViewportProps = {
  * @param options fit bounds parameters
  * @returns - latitude, longitude and zoom
  */
-export default function fitBounds(options: FitBoundsOptions): ViewportProps {
+export function fitBounds(options: FitBoundsOptions): ViewportProps {
   const {
     width,
     height,

--- a/modules/web-mercator/src/fly-to-viewport.ts
+++ b/modules/web-mercator/src/fly-to-viewport.ts
@@ -24,7 +24,7 @@ export type FlytoTransitionOptions = {
  * It implements “Smooth and efficient zooming and panning.” algorithm by
  * "Jarke J. van Wijk and Wim A.A. Nuij"
  */
-export default function flyToViewport(
+export function flyToViewport(
   startProps: ViewportProps,
   endProps: ViewportProps,
   t: number,

--- a/modules/web-mercator/src/get-bounds.ts
+++ b/modules/web-mercator/src/get-bounds.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import {lerp as vec2_lerp} from 'gl-matrix/vec2';
-import type WebMercatorViewport from './web-mercator-viewport';
+import type {WebMercatorViewport} from './web-mercator-viewport';
 import {worldToLngLat} from './web-mercator-utils';
 import {transformVector} from './math-utils';
 
@@ -11,7 +11,7 @@ const DEGREES_TO_RADIANS = Math.PI / 180;
  * @param {WebMercatorViewport} viewport
  * @param {Number} z - elevation in meters
  */
-export default function getBounds(viewport: WebMercatorViewport, z: number = 0): number[][] {
+export function getBounds(viewport: WebMercatorViewport, z: number = 0): number[][] {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const {width, height, unproject} = viewport;
   const unprojectOps = {targetZ: z};

--- a/modules/web-mercator/src/index.ts
+++ b/modules/web-mercator/src/index.ts
@@ -1,11 +1,10 @@
 // Classic web-mercator-project
-export {default} from './web-mercator-viewport';
-export {default as WebMercatorViewport} from './web-mercator-viewport';
+export {WebMercatorViewport} from './web-mercator-viewport';
 
-export {default as getBounds} from './get-bounds';
-export {default as fitBounds} from './fit-bounds';
-export {default as normalizeViewportProps} from './normalize-viewport-props';
-export {default as flyToViewport, getFlyToDuration} from './fly-to-viewport';
+export {getBounds} from './get-bounds';
+export {fitBounds} from './fit-bounds';
+export {normalizeViewportProps} from './normalize-viewport-props';
+export {flyToViewport, getFlyToDuration} from './fly-to-viewport';
 
 export {
   MAX_LATITUDE,
@@ -29,3 +28,6 @@ export {
 /** Types */
 export type {FitBoundsOptions} from './fit-bounds';
 export type {DistanceScales} from './web-mercator-utils';
+
+/** @deprecated default export */
+export {WebMercatorViewport as default} from './web-mercator-viewport';

--- a/modules/web-mercator/src/normalize-viewport-props.ts
+++ b/modules/web-mercator/src/normalize-viewport-props.ts
@@ -20,7 +20,7 @@ export type ViewportProps = {
  * @param props
  */
 // eslint-disable-next-line complexity
-export default function normalizeViewportProps(props: ViewportProps): ViewportProps {
+export function normalizeViewportProps(props: ViewportProps): ViewportProps {
   const {width, height, pitch = 0} = props;
   let {longitude, latitude, zoom, bearing = 0} = props;
 

--- a/modules/web-mercator/src/web-mercator-utils.ts
+++ b/modules/web-mercator/src/web-mercator-utils.ts
@@ -5,7 +5,7 @@ import {createMat4, transformVector, clamp, log2} from './math-utils';
 import * as mat4 from 'gl-matrix/mat4';
 import * as vec2 from 'gl-matrix/vec2';
 import * as vec3 from 'gl-matrix/vec3';
-import assert from './assert';
+import {assert} from './assert';
 
 // CONSTANTS
 const PI = Math.PI;

--- a/modules/web-mercator/src/web-mercator-viewport.ts
+++ b/modules/web-mercator/src/web-mercator-viewport.ts
@@ -15,8 +15,8 @@ import {
   getViewMatrix,
   DistanceScales
 } from './web-mercator-utils';
-import fitBounds from './fit-bounds';
-import getBounds from './get-bounds';
+import {fitBounds} from './fit-bounds';
+import {getBounds} from './get-bounds';
 import type {FitBoundsOptions} from './fit-bounds';
 
 import * as mat4 from 'gl-matrix/mat4';
@@ -70,7 +70,7 @@ export type WebMercatorViewportProps = {
  * Note: Instances are immutable in the sense that they only have accessors.
  * A new viewport instance should be created if any parameters have changed.
  */
-export default class WebMercatorViewport {
+export class WebMercatorViewport {
   readonly latitude: number;
   readonly longitude: number;
   readonly zoom: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,6 +344,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
   integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
 
+"@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2":
+  version "7.20.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz#d1b9000752b18d0877cff85a5c376ce5c3121629"
+  integrity sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==
+
 "@babel/helper-remap-async-to-generator@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.14.5.tgz#51439c913612958f54a987a4ffc9ee587a2045d6"
@@ -394,6 +399,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-skip-transparent-expression-wrappers@^7.20.0":
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz#fbe4c52f60518cab8140d77101f0e63a8a230684"
+  integrity sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==
+  dependencies:
+    "@babel/types" "^7.20.0"
+
 "@babel/helper-split-export-declaration@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
@@ -408,6 +420,11 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-string-parser@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
+  integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
+
 "@babel/helper-validator-identifier@^7.14.0":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
@@ -417,6 +434,11 @@
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
   integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
+
+"@babel/helper-validator-identifier@^7.19.1":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
 
 "@babel/helper-validator-option@^7.12.17":
   version "7.12.17"
@@ -551,6 +573,14 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.14.2":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz#fdd940a99a740e577d6c753ab6fbb43fdb9467e1"
+  integrity sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+
 "@babel/plugin-proposal-nullish-coalescing-operator@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz#ee38589ce00e2cc59b299ec3ea406fcd3a0fdaf6"
@@ -585,6 +615,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+
+"@babel/plugin-proposal-optional-chaining@^7.14.2":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz#886f5c8978deb7d30f678b2e24346b287234d3ea"
+  integrity sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.20.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
 "@babel/plugin-proposal-optional-chaining@^7.14.5":
   version "7.14.5"
@@ -1225,6 +1264,17 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/register@^7.14.5":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.21.0.tgz#c97bf56c2472e063774f31d344c592ebdcefa132"
+  integrity sha512-9nKsPmYDi5DidAqJaQooxIhsLJiNMkGr8ypQ8Uic7cIox7UCDsM7HuUGxdGT7mSDTYbqzIdsOWzfBton/YJrMw==
+  dependencies:
+    clone-deep "^4.0.1"
+    find-cache-dir "^2.0.0"
+    make-dir "^2.1.0"
+    pirates "^4.0.5"
+    source-map-support "^0.5.16"
+
 "@babel/runtime-corejs3@^7.10.2":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.14.0.tgz#6bf5fbc0b961f8e3202888cb2cd0fb7a0a9a3f66"
@@ -1310,10 +1360,14 @@
     "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
-"@bcoe/v8-coverage@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
-  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+"@babel/types@^7.20.0":
+  version "7.21.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.2.tgz#92246f6e00f91755893c2876ad653db70c8310d1"
+  integrity sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -1559,7 +1613,7 @@
     js-yaml "^3.13.1"
     resolve-from "^5.0.0"
 
-"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
+"@istanbuljs/schema@^0.1.2":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
@@ -1604,7 +1658,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@^0.3.9":
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
   integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
@@ -2626,11 +2680,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/istanbul-lib-coverage@^2.0.1":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
-  integrity sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==
-
 "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
@@ -3049,6 +3098,14 @@ agentkeepalive@^3.4.1:
   dependencies:
     humanize-ms "^1.2.1"
 
+aggregate-error@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
+  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
+
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -3159,6 +3216,13 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+append-transform@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-2.0.0.tgz#99d9d29c7b38391e6f428d28ce136551f0b77e12"
+  integrity sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==
+  dependencies:
+    default-require-extensions "^3.0.0"
+
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -3168,6 +3232,11 @@ aproba@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
+
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+  integrity sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==
 
 are-we-there-yet@~1.1.2:
   version "1.1.5"
@@ -3367,7 +3436,7 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async@^2.6.2:
+async@^2.5.0, async@^2.6.2:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
   integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
@@ -3444,13 +3513,6 @@ babel-messages@^6.23.0:
   integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
   dependencies:
     babel-runtime "^6.22.0"
-
-babel-plugin-add-import-extension@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.6.0.tgz#807ce65b38d4763797c1616cb4e8372da167cdd1"
-  integrity sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -3595,6 +3657,11 @@ before-after-hook@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.1.tgz#73540563558687586b52ed217dad6a802ab1549c"
   integrity sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==
+
+big.js@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
+  integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -3864,24 +3931,6 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-c8@^7.12.0:
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/c8/-/c8-7.13.0.tgz#a2a70a851278709df5a9247d62d7f3d4bcb5f2e4"
-  integrity sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==
-  dependencies:
-    "@bcoe/v8-coverage" "^0.2.3"
-    "@istanbuljs/schema" "^0.1.3"
-    find-up "^5.0.0"
-    foreground-child "^2.0.0"
-    istanbul-lib-coverage "^3.2.0"
-    istanbul-lib-report "^3.0.0"
-    istanbul-reports "^3.1.4"
-    rimraf "^3.0.2"
-    test-exclude "^6.0.0"
-    v8-to-istanbul "^9.0.0"
-    yargs "^16.2.0"
-    yargs-parser "^20.2.9"
-
 cacache@^12.0.0, cacache@^12.0.2, cacache@^12.0.3:
   version "12.0.4"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.4.tgz#668bcbd105aeb5f1d92fe25570ec9525c8faa40c"
@@ -3917,6 +3966,16 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+caching-transform@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-4.0.0.tgz#00d297a4206d71e2163c39eaffa8157ac0651f0f"
+  integrity sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==
+  dependencies:
+    hasha "^5.0.0"
+    make-dir "^3.0.0"
+    package-hash "^4.0.0"
+    write-file-atomic "^3.0.0"
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
@@ -3954,6 +4013,14 @@ callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+camel-case@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
+  integrity sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.1"
 
 camel-case@^4.1.2:
   version "4.1.2"
@@ -4142,12 +4209,24 @@ classnames@^2.2.5:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
+clean-css@4.2.x:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.4.tgz#733bf46eba4e607c6891ea57c24a989356831178"
+  integrity sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==
+  dependencies:
+    source-map "~0.6.0"
+
 clean-css@^5.2.2:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.1.tgz#d0610b0b90d125196a2894d35366f734e5d7aa32"
   integrity sha512-lCr8OHhiWCTw4v8POJovCoh4T7I9U11yVsPjMWWnnMmp9ZowCxyad1Pathle/9HjaDp+fdQKjO9fQydE6RHTZg==
   dependencies:
     source-map "~0.6.0"
+
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -4170,14 +4249,14 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
-cliui@^7.0.2:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
-  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
-    wrap-ansi "^7.0.0"
+    wrap-ansi "^6.2.0"
 
 clone-deep@^4.0.1:
   version "4.0.1"
@@ -4255,6 +4334,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.17.x:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+  integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
+
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -4269,6 +4353,11 @@ commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
+commander@~2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -4340,6 +4429,11 @@ config-chain@^1.1.11:
   dependencies:
     ini "^1.3.4"
     proto-list "~1.2.1"
+
+confusing-browser-globals@^1.0.10:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
+  integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
 
 connect-history-api-fallback@^1.6.0:
   version "1.6.0"
@@ -4473,11 +4567,6 @@ convert-source-map@^1.1.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-convert-source-map@^1.6.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
-  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
-
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -4522,6 +4611,11 @@ core-js@^2.4.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
+
+core-js@^3.2.1:
+  version "3.29.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.29.0.tgz#0273e142b67761058bcde5615c503c7406b572d6"
+  integrity sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -4605,7 +4699,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -4648,7 +4742,7 @@ css-loader@^2.1.1:
     postcss-value-parser "^3.3.0"
     schema-utils "^1.0.0"
 
-css-select@^4.2.1:
+css-select@^4.1.3, css-select@^4.2.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.3.0.tgz#db7129b2846662fd8628cfc496abb2b59e41529b"
   integrity sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==
@@ -4817,6 +4911,13 @@ default-gateway@^4.2.0:
   dependencies:
     execa "^1.0.0"
     ip-regex "^2.1.0"
+
+default-require-extensions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-3.0.1.tgz#bfae00feeaeada68c2ae256c62540f60b80625bd"
+  integrity sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==
+  dependencies:
+    strip-bom "^4.0.0"
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -5016,6 +5117,13 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-converter@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
+  integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
+  dependencies:
+    utila "~0.4"
+
 dom-serializer@^1.0.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
@@ -5040,14 +5148,14 @@ domelementtype@^2.2.0:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
-domhandler@^4.2.0, domhandler@^4.3.1:
+domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
 
-domutils@^2.8.0:
+domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
   integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
@@ -5160,6 +5268,11 @@ emoji-regex@^9.0.0:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+emojis-list@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
+  integrity sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==
 
 emojis-list@^3.0.0:
   version "3.0.0"
@@ -5292,6 +5405,11 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es6-error@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
+  integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
+
 es6-promise@^4.0.3:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
@@ -5303,15 +5421,6 @@ es6-promisify@^5.0.0:
   integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
-
-"esbuild-plugin-babel@git+https://github.com/Pessimistress/esbuild-plugin-babel.git#patch-1":
-  version "0.2.3"
-  resolved "git+https://github.com/Pessimistress/esbuild-plugin-babel.git#0c081a5436ae0e703d97eff28fe77edfc1e30e4a"
-
-esbuild-plugin-external-global@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/esbuild-plugin-external-global/-/esbuild-plugin-external-global-1.0.1.tgz#e3bba0e3a561f61b395bec0984a90ed0de06c4ce"
-  integrity sha512-NDzYHRoShpvLqNcrgV8ZQh61sMIFAry5KLTQV83BPG5iTXCCu7h72SCfJ97bW0GqtuqDD/1aqLbKinI/rNgUsg==
 
 esbuild@^0.16.3, esbuild@^0.16.7:
   version "0.16.7"
@@ -5372,6 +5481,24 @@ escodegen@^1.6.1:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+eslint-config-airbnb-base@^14.2.1:
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz#8a2eb38455dc5a312550193b319cdaeef042cd1e"
+  integrity sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==
+  dependencies:
+    confusing-browser-globals "^1.0.10"
+    object.assign "^4.1.2"
+    object.entries "^1.1.2"
+
+eslint-config-airbnb@^18.0.1:
+  version "18.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz#b7fe2b42f9f8173e825b73c8014b592e449c98d9"
+  integrity sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==
+  dependencies:
+    eslint-config-airbnb-base "^14.2.1"
+    object.assign "^4.1.2"
+    object.entries "^1.1.2"
 
 eslint-config-prettier@^6.7.0:
   version "6.15.0"
@@ -5974,6 +6101,15 @@ find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
+find-cache-dir@^3.2.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
+  integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
+
 find-cache-dir@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
@@ -6011,14 +6147,6 @@ find-up@^4.0.0, find-up@^4.1.0:
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
     locate-path "^5.0.0"
-    path-exists "^4.0.0"
-
-find-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
     path-exists "^4.0.0"
 
 findup-sync@^3.0.0:
@@ -6115,6 +6243,11 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fromentries@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
+  integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -6233,7 +6366,7 @@ geojson-vt@^3.2.1:
   resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.2.1.tgz#f8adb614d2c1d3f6ee7c4265cad4bbf3ad60c8b7"
   integrity sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==
 
-get-caller-file@^2.0.1, get-caller-file@^2.0.5:
+get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -6431,6 +6564,18 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@~7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.6:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global-modules@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
@@ -6550,7 +6695,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
-handlebars@^4.7.6:
+handlebars@^4.1.2, handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -6691,7 +6836,15 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-he@1.2.0, he@^1.2.0:
+hasha@^5.0.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/hasha/-/hasha-5.2.2.tgz#a48477989b3b327aea3c04f53096d816d97522a1"
+  integrity sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==
+  dependencies:
+    is-stream "^2.0.0"
+    type-fest "^0.8.0"
+
+he@1.2.0, he@1.2.x, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -6763,6 +6916,42 @@ html-minifier-terser@^6.1.0:
     param-case "^3.0.4"
     relateurl "^0.2.7"
     terser "^5.10.0"
+
+html-minifier@^3.2.3:
+  version "3.5.21"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.21.tgz#d0040e054730e354db008463593194015212d20c"
+  integrity sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==
+  dependencies:
+    camel-case "3.0.x"
+    clean-css "4.2.x"
+    commander "2.17.x"
+    he "1.2.x"
+    param-case "2.1.x"
+    relateurl "0.2.x"
+    uglify-js "3.4.x"
+
+html-webpack-plugin@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz#b01abbd723acaaa7b37b6af4492ebda03d9dd37b"
+  integrity sha512-Br4ifmjQojUP4EmHnRBoUIYcZ9J7M4bTMcm7u6xoIAIuq2Nte4TzXX0533owvkQKQD1WeMTTTyD4Ni4QKxS0Bg==
+  dependencies:
+    html-minifier "^3.2.3"
+    loader-utils "^0.2.16"
+    lodash "^4.17.3"
+    pretty-error "^2.0.2"
+    tapable "^1.0.0"
+    toposort "^1.0.0"
+    util.promisify "1.0.0"
+
+htmlparser2@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
 
 http-cache-semantics@^3.8.1:
   version "3.8.1"
@@ -7055,7 +7244,7 @@ internal-slot@^1.0.4:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-interpret@^1.4.0:
+interpret@^1.0.0, interpret@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
@@ -7410,6 +7599,11 @@ is-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
 is-string@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
@@ -7447,7 +7641,7 @@ is-typed-array@^1.1.10, is-typed-array@^1.1.9:
     gopd "^1.0.1"
     has-tostringtag "^1.0.0"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -7511,6 +7705,13 @@ istanbul-lib-coverage@^3.2.0:
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz#189e7909d0a39fa5a3dfad5b03f71947770191d3"
   integrity sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==
 
+istanbul-lib-hook@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz#8f84c9434888cc6b1d0a9d7092a76d239ebf0cc6"
+  integrity sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==
+  dependencies:
+    append-transform "^2.0.0"
+
 istanbul-lib-instrument@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz#873c6fff897450118222774696a3f28902d77c1d"
@@ -7521,6 +7722,18 @@ istanbul-lib-instrument@^4.0.0:
     istanbul-lib-coverage "^3.0.0"
     semver "^6.3.0"
 
+istanbul-lib-processinfo@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz#366d454cd0dcb7eb6e0e419378e60072c8626169"
+  integrity sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==
+  dependencies:
+    archy "^1.0.0"
+    cross-spawn "^7.0.3"
+    istanbul-lib-coverage "^3.2.0"
+    p-map "^3.0.0"
+    rimraf "^3.0.0"
+    uuid "^8.3.2"
+
 istanbul-lib-report@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#7518fe52ea44de372f460a76b5ecda9ffb73d8a6"
@@ -7530,7 +7743,16 @@ istanbul-lib-report@^3.0.0:
     make-dir "^3.0.0"
     supports-color "^7.1.0"
 
-istanbul-reports@^3.1.4:
+istanbul-lib-source-maps@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz#895f3a709fcfba34c6de5a42939022f3e4358551"
+  integrity sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==
+  dependencies:
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+    source-map "^0.6.1"
+
+istanbul-reports@^3.0.2:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.5.tgz#cc9a6ab25cb25659810e4785ed9d9fb742578bae"
   integrity sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==
@@ -7645,6 +7867,11 @@ json3@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
+
+json5@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==
 
 json5@^1.0.1:
   version "1.0.1"
@@ -7842,6 +8069,16 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
+loader-utils@^0.2.16:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
+  integrity sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+    object-assign "^4.0.1"
+
 loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
@@ -7883,13 +8120,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-locate-path@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
-  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
-  dependencies:
-    p-locate "^5.0.0"
-
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -7904,6 +8134,11 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==
 
 lodash.get@^4.4.2:
   version "4.4.2"
@@ -7955,7 +8190,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7994,6 +8229,11 @@ loud-rejection@^1.0.0:
   dependencies:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
+
+lower-case@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+  integrity sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==
 
 lower-case@^2.0.2:
   version "2.0.2"
@@ -8355,7 +8595,7 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.4:
+minimatch@^3.0.4, minimatch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -8471,6 +8711,11 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+module-alias@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
+  integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -8593,6 +8838,13 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+no-case@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
+  integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
+  dependencies:
+    lower-case "^1.1.1"
+
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
@@ -8680,6 +8932,13 @@ node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
+
+node-preload@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/node-preload/-/node-preload-0.2.1.tgz#c03043bb327f417a18fee7ab7ee57b408a144301"
+  integrity sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==
+  dependencies:
+    process-on-spawn "^1.0.0"
 
 node-releases@^1.1.71:
   version "1.1.72"
@@ -8819,6 +9078,39 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
   integrity sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==
 
+nyc@^15.0.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-15.1.0.tgz#1335dae12ddc87b6e249d5a1994ca4bdaea75f02"
+  integrity sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==
+  dependencies:
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.2"
+    caching-transform "^4.0.0"
+    convert-source-map "^1.7.0"
+    decamelize "^1.2.0"
+    find-cache-dir "^3.2.0"
+    find-up "^4.1.0"
+    foreground-child "^2.0.0"
+    get-package-type "^0.1.0"
+    glob "^7.1.6"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-hook "^3.0.0"
+    istanbul-lib-instrument "^4.0.0"
+    istanbul-lib-processinfo "^2.0.2"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.2"
+    make-dir "^3.0.0"
+    node-preload "^0.2.1"
+    p-map "^3.0.0"
+    process-on-spawn "^1.0.0"
+    resolve-from "^5.0.0"
+    rimraf "^3.0.0"
+    signal-exit "^3.0.2"
+    spawn-wrap "^2.0.0"
+    test-exclude "^6.0.0"
+    yargs "^15.0.2"
+
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -8893,6 +9185,15 @@ object.assign@^4.1.4:
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
+object.entries@^1.1.2:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.6.tgz#9737d0e5b8291edd340a3e3264bb8a3b00d5fa23"
+  integrity sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
 object.entries@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.4.tgz#43ccf9a50bc5fd5b649d45ab1a579f24e088cafd"
@@ -8947,18 +9248,22 @@ octokit-pagination-methods@^1.1.0:
   resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
   integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
 
-ocular-dev-tools@2.0.0-alpha.8:
-  version "2.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-2.0.0-alpha.8.tgz#07782d7cb9d8fd312ee55f3f3f94d486c721c903"
-  integrity sha512-NlM7EqY4nCU7WgVdgSBXgp05a1SKCsJSuzHUKxieRN6+R1SQdkn6L+Fo+THNWCaMS8jtBstzoSfL73xmateHtQ==
+ocular-dev-tools@2.0.0-alpha.3:
+  version "2.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/ocular-dev-tools/-/ocular-dev-tools-2.0.0-alpha.3.tgz#ce6606be4de4830d8e1fcf3e324e973566be9679"
+  integrity sha512-DmekCGYYTpUIR/MrG6lugnM5Prvz/SgVqDWNZpMD01Fez4gZurllknkNxVCVETZjdaoOUYUtWKzsRpDWheEvsw==
   dependencies:
     "@babel/cli" "^7.14.5"
     "@babel/core" "^7.14.5"
     "@babel/eslint-parser" "^7.14.5"
+    "@babel/plugin-proposal-class-properties" "^7.14.5"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.14.2"
+    "@babel/plugin-proposal-optional-chaining" "^7.14.2"
     "@babel/plugin-transform-runtime" "^7.14.5"
     "@babel/preset-env" "^7.14.5"
     "@babel/preset-react" "^7.14.5"
     "@babel/preset-typescript" "^7.14.5"
+    "@babel/register" "^7.14.5"
     "@babel/runtime" "7.14.5"
     "@esbuild-plugins/node-globals-polyfill" "^0.1.1"
     "@esbuild-plugins/node-modules-polyfill" "^0.1.4"
@@ -8966,16 +9271,14 @@ ocular-dev-tools@2.0.0-alpha.8:
     "@typescript-eslint/eslint-plugin" "^4.26.1"
     "@typescript-eslint/parser" "^4.26.1"
     babel-loader "8.2.2"
-    babel-plugin-add-import-extension "^1.6.0"
     babel-plugin-istanbul "^6.0.0"
     babel-plugin-version-inline "^1.0.0"
-    c8 "^7.12.0"
+    core-js "^3.2.1"
     coveralls "^3.0.3"
     deepmerge "^4.2.2"
     esbuild "^0.16.7"
-    esbuild-plugin-babel "git+https://github.com/Pessimistress/esbuild-plugin-babel.git#patch-1"
-    esbuild-plugin-external-global "^1.0.1"
     eslint "^7.32.0"
+    eslint-config-airbnb "^18.0.1"
     eslint-config-prettier "^6.7.0"
     eslint-config-uber-es2015 "^3.0.0"
     eslint-config-uber-jsx "^3.3.3"
@@ -8986,15 +9289,23 @@ ocular-dev-tools@2.0.0-alpha.8:
     eslint-plugin-react "^7.22.0"
     eslint-plugin-react-hooks "^4.0.0"
     glob "^7.1.4"
+    handlebars "^4.1.2"
+    html-webpack-plugin "^3.2.0"
     lerna "^3.14.1"
+    lodash "^4.17.13"
+    lodash.template "^4.5.0"
+    module-alias "^2.0.0"
+    nyc "^15.0.0"
     prettier "2.4.1"
     prettier-check "2.0.0"
+    shelljs "^0.8.5"
+    source-map-loader "^0.2.3"
+    source-map-support "^0.5.12"
     tape "^4.11.0"
     tape-promise "^4.0.0"
     ts-node "~10.9.0"
     tsconfig-paths "^4.1.1"
     typescript "~4.6.0"
-    url "^0.11.0"
     vite "^4.0.1"
     vite-plugin-html "^3.2.0"
 
@@ -9117,13 +9428,6 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
-  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
-  dependencies:
-    yocto-queue "^0.1.0"
-
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -9145,13 +9449,6 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
-p-locate@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
-  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
-  dependencies:
-    p-limit "^3.0.2"
-
 p-map-series@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-map-series/-/p-map-series-1.0.0.tgz#bf98fe575705658a9e1351befb85ae4c1f07bdca"
@@ -9163,6 +9460,13 @@ p-map@^2.0.0, p-map@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
+p-map@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-3.0.0.tgz#d704d9af8a2ba684e2600d9a215983d4141a979d"
+  integrity sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==
+  dependencies:
+    aggregate-error "^3.0.0"
 
 p-pipe@^1.2.0:
   version "1.2.0"
@@ -9205,6 +9509,16 @@ p-waterfall@^1.0.0:
   dependencies:
     p-reduce "^1.0.0"
 
+package-hash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/package-hash/-/package-hash-4.0.0.tgz#3537f654665ec3cc38827387fc904c163c54f506"
+  integrity sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==
+  dependencies:
+    graceful-fs "^4.1.15"
+    hasha "^5.0.0"
+    lodash.flattendeep "^4.4.0"
+    release-zalgo "^1.0.0"
+
 pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -9218,6 +9532,13 @@ parallel-transform@^1.1.0:
     cyclist "^1.0.1"
     inherits "^2.0.3"
     readable-stream "^2.1.5"
+
+param-case@2.1.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
+  integrity sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==
+  dependencies:
+    no-case "^2.2.0"
 
 param-case@^3.0.4:
   version "3.0.4"
@@ -9496,6 +9817,11 @@ pirates@^4.0.0:
   dependencies:
     node-modules-regexp "^1.0.0"
 
+pirates@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
+  integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
+
 pixelmatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pixelmatch/-/pixelmatch-4.0.2.tgz#8f47dcec5011b477b67db03c243bc1f3085e8854"
@@ -9649,10 +9975,25 @@ prettier@2.4.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
+pretty-error@^2.0.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.2.tgz#be89f82d81b1c86ec8fdfbc385045882727f93b6"
+  integrity sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==
+  dependencies:
+    lodash "^4.17.20"
+    renderkid "^2.0.4"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+process-on-spawn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/process-on-spawn/-/process-on-spawn-1.0.0.tgz#95b05a23073d30a17acfdc92a440efd2baefdc93"
+  integrity sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==
+  dependencies:
+    fromentries "^1.2.0"
 
 process@^0.11.10:
   version "0.11.10"
@@ -10080,6 +10421,13 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
+  dependencies:
+    resolve "^1.1.6"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -10187,15 +10535,33 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
-relateurl@^0.2.7:
+relateurl@0.2.x, relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
+
+release-zalgo@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/release-zalgo/-/release-zalgo-1.0.0.tgz#09700b7e5074329739330e535c5a90fb67851730"
+  integrity sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==
+  dependencies:
+    es6-error "^4.0.1"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
+renderkid@^2.0.4:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.7.tgz#464f276a6bdcee606f4a15993f9b29fc74ca8609"
+  integrity sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==
+  dependencies:
+    css-select "^4.1.3"
+    dom-converter "^0.2.0"
+    htmlparser2 "^6.1.0"
+    lodash "^4.17.21"
+    strip-ansi "^3.0.1"
 
 repeat-element@^1.1.2:
   version "1.1.4"
@@ -10302,15 +10668,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.20.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
-  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
-  dependencies:
-    is-core-module "^2.2.0"
-    path-parse "^1.0.6"
-
-resolve@^1.22.1:
+resolve@^1.1.6, resolve@^1.22.1:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -10318,6 +10676,14 @@ resolve@^1.22.1:
     is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.10.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.20.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  dependencies:
+    is-core-module "^2.2.0"
+    path-parse "^1.0.6"
 
 resolve@^2.0.0-next.3:
   version "2.0.0-next.3"
@@ -10376,7 +10742,7 @@ rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -10673,6 +11039,15 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shelljs@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -10800,6 +11175,14 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map-loader@^0.2.3:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-0.2.4.tgz#c18b0dc6e23bf66f6792437557c569a11e072271"
+  integrity sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==
+  dependencies:
+    async "^2.5.0"
+    loader-utils "^1.1.0"
+
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -10811,7 +11194,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.16, source-map-support@~0.5.12, source-map-support@~0.5.20:
+source-map-support@^0.5.12, source-map-support@^0.5.16, source-map-support@~0.5.12, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -10846,6 +11229,18 @@ spawn-sync@^1.0.15:
   dependencies:
     concat-stream "^1.4.7"
     os-shim "^0.1.2"
+
+spawn-wrap@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-2.0.0.tgz#103685b8b8f9b79771318827aa78650a610d457e"
+  integrity sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==
+  dependencies:
+    foreground-child "^2.0.0"
+    is-windows "^1.0.2"
+    make-dir "^3.0.0"
+    rimraf "^3.0.0"
+    signal-exit "^3.0.2"
+    which "^2.0.1"
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -11140,6 +11535,11 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
+strip-bom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
+  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -11504,6 +11904,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+toposort@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
+  integrity sha512-FclLrw8b9bMWf4QlCJuHBEVhSRsqDj6u3nIjAzPeJvgl//1hBlffdlk0MALceL14+koWEdU4ofRAXofbODxQzg==
+
 tough-cookie@^2.3.2, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -11650,7 +12055,7 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-type-fest@^0.8.1:
+type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
@@ -11672,6 +12077,13 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -11686,6 +12098,14 @@ typescript@~4.6.0:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+
+uglify-js@3.4.x:
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.10.tgz#9ad9563d8eb3acdfb8d38597d2af1d815f6a755f"
+  integrity sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==
+  dependencies:
+    commander "~2.19.0"
+    source-map "~0.6.1"
 
 uglify-js@^3.1.4:
   version "3.13.8"
@@ -11814,6 +12234,11 @@ upath@^1.1.1, upath@^1.2.0:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
+upper-case@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
+  integrity sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
@@ -11859,6 +12284,14 @@ util-promisify@^2.1.0:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
 
+util.promisify@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
+  dependencies:
+    define-properties "^1.1.2"
+    object.getownpropertydescriptors "^2.0.3"
+
 util@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
@@ -11873,6 +12306,11 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
+utila@~0.4:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
+  integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
+
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
@@ -11883,6 +12321,11 @@ uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -11892,15 +12335,6 @@ v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
-
-v8-to-istanbul@^9.0.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz#1b83ed4e397f58c85c266a570fc2558b5feb9265"
-  integrity sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==
-  dependencies:
-    "@jridgewell/trace-mapping" "^0.3.12"
-    "@types/istanbul-lib-coverage" "^2.0.1"
-    convert-source-map "^1.6.0"
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3:
   version "3.0.4"
@@ -12269,10 +12703,10 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -12291,6 +12725,16 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write-file-atomic@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
 
 write-json-file@^2.2.0:
   version "2.3.0"
@@ -12351,11 +12795,6 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
-y18n@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
-  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -12387,10 +12826,13 @@ yargs-parser@^15.0.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^20.2.2, yargs-parser@^20.2.9:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-parser@^20.2.3:
   version "20.2.7"
@@ -12430,18 +12872,22 @@ yargs@^14.2.2:
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
 
-yargs@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+yargs@^15.0.2:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
   dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
     require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
     string-width "^4.2.0"
-    y18n "^5.0.5"
-    yargs-parser "^20.2.2"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yauzl@^2.10.0:
   version "2.10.0"
@@ -12455,8 +12901,3 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
-
-yocto-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
-  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
Note: Affects internal code only, not external APIs

Just a nit, in that default exports remove information and prevent the compiler from checking that the correct symbols are being referenced. While the do convey information about what the primary export in a file is, the convention in this repo is mainly one export per file.