### PR TITLE
chore(core): added Matrix4.fromTranslationQuaternion

### DIFF
--- a/docs/modules/core/api-reference/matrix4.md
+++ b/docs/modules/core/api-reference/matrix4.md
@@ -99,6 +99,15 @@ Sets the matrix to a transformation corresponding to the rotations represented b
 
 - `quaternion` (`Quaternion`) - the quaternion to create matrix from
 
+##### fromTranslationQuaternion(translation: Vector3, quaternion: Quaternion): this
+
+Sets the matrix to a transformation corresponding to the translation and rotations represented by the given parameters.
+
+`matrix4.fromTranslationQuaternion(translation, quaternion)`
+
+- `translation` (`Vector3`) - the translation to create matrix from
+- `quaternion` (`Quaternion`) - the quaternion to create matrix from
+
 ##### frustum(options: {left: number, right: number, bottom: number, top: number, near: number, far: number}): this
 
 Generates a frustum matrix with the given bounds. The frustum far plane can be infinite.

--- a/modules/core/src/classes/matrix4.ts
+++ b/modules/core/src/classes/matrix4.ts
@@ -3,6 +3,8 @@
 
 import {NumericArray} from '@math.gl/types';
 import {Matrix} from './base/matrix';
+import {Matrix3} from './matrix3';
+import {Vector3} from './vector3';
 import {checkVector} from '../lib/validators';
 
 /* eslint-disable camelcase */
@@ -219,6 +221,20 @@ export class Matrix4 extends Matrix {
   }
 
   /**
+   * Calculates a 4x4 matrix from the given translation and quaternion
+   * @param translation Vector3 to create matrix from
+   * @param quaternion Quaternion to create matrix from
+   * @returns self
+   */
+  fromTranslationQuaternion(
+    translation: Readonly<NumericArray>,
+    quaternion: Readonly<NumericArray>
+  ): this {
+    mat4.fromRotationTranslation(this, quaternion, translation);
+    return this.check();
+  }
+
+  /**
    * Generates a frustum matrix with the given bounds
    * @param view.left - Left bound of the frustum
    * @param view.right - Right bound of the frustum
@@ -355,7 +371,9 @@ export class Matrix4 extends Matrix {
    * @param result
    * @returns self
    */
-  getScale(result: NumericArray = [-0, -0, -0]): NumericArray {
+  getScale(): Vector3;
+  getScale<T extends NumericArray>(result: T): T;
+  getScale(result = new Vector3()): Vector3 {
     // explicit is faster than hypot...
     result[0] = Math.sqrt(this[0] * this[0] + this[1] * this[1] + this[2] * this[2]);
     result[1] = Math.sqrt(this[4] * this[4] + this[5] * this[5] + this[6] * this[6]);
@@ -371,7 +389,9 @@ export class Matrix4 extends Matrix {
    * @param result
    * @returns self
    */
-  getTranslation(result: NumericArray = [-0, -0, -0]): NumericArray {
+  getTranslation(): Vector3;
+  getTranslation<T extends NumericArray>(result: T): T;
+  getTranslation(result = new Vector3()): Vector3 {
     result[0] = this[12];
     result[1] = this[13];
     result[2] = this[14];
@@ -384,8 +404,9 @@ export class Matrix4 extends Matrix {
    * @param scaleResult
    * @returns self
    */
-  getRotation(result?: NumericArray, scaleResult?: NumericArray): NumericArray {
-    result = result || [-0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0];
+  getRotation(scaleResult?: NumericArray): Matrix4;
+  getRotation<T extends NumericArray>(result: T, scaleResult?: NumericArray): T;
+  getRotation(result = new Matrix4(), scaleResult?: NumericArray): Matrix4 {
     scaleResult = scaleResult || [-0, -0, -0];
     const scale = this.getScale(scaleResult);
     const inverseScale0 = 1 / scale[0];
@@ -416,8 +437,9 @@ export class Matrix4 extends Matrix {
    * @param scaleResult
    * @returns self
    */
-  getRotationMatrix3(result?: NumericArray, scaleResult?: NumericArray): NumericArray {
-    result = result || [-0, -0, -0, -0, -0, -0, -0, -0, -0];
+  getRotationMatrix3(scaleResult?: NumericArray): Matrix3;
+  getRotationMatrix3<T extends NumericArray>(result: T, scaleResult?: NumericArray): T;
+  getRotationMatrix3(result = new Matrix3(), scaleResult?: NumericArray): Matrix3 {
     scaleResult = scaleResult || [-0, -0, -0];
     const scale = this.getScale(scaleResult);
     const inverseScale0 = 1 / scale[0];

--- a/modules/core/src/classes/matrix4.ts
+++ b/modules/core/src/classes/matrix4.ts
@@ -3,8 +3,6 @@
 
 import {NumericArray} from '@math.gl/types';
 import {Matrix} from './base/matrix';
-import {Matrix3} from './matrix3';
-import {Vector3} from './vector3';
 import {checkVector} from '../lib/validators';
 
 /* eslint-disable camelcase */
@@ -371,9 +369,9 @@ export class Matrix4 extends Matrix {
    * @param result
    * @returns self
    */
-  getScale(): Vector3;
+  getScale(): NumericArray;
   getScale<T extends NumericArray>(result: T): T;
-  getScale(result = new Vector3()): Vector3 {
+  getScale(result = [-0, -0, -0]): NumericArray {
     // explicit is faster than hypot...
     result[0] = Math.sqrt(this[0] * this[0] + this[1] * this[1] + this[2] * this[2]);
     result[1] = Math.sqrt(this[4] * this[4] + this[5] * this[5] + this[6] * this[6]);
@@ -389,9 +387,9 @@ export class Matrix4 extends Matrix {
    * @param result
    * @returns self
    */
-  getTranslation(): Vector3;
+  getTranslation(): NumericArray;
   getTranslation<T extends NumericArray>(result: T): T;
-  getTranslation(result = new Vector3()): Vector3 {
+  getTranslation(result = [-0, -0, -0]): NumericArray {
     result[0] = this[12];
     result[1] = this[13];
     result[2] = this[14];
@@ -404,9 +402,12 @@ export class Matrix4 extends Matrix {
    * @param scaleResult
    * @returns self
    */
-  getRotation(scaleResult?: NumericArray): Matrix4;
+  getRotation(scaleResult?: NumericArray): NumericArray;
   getRotation<T extends NumericArray>(result: T, scaleResult?: NumericArray): T;
-  getRotation(result = new Matrix4(), scaleResult?: NumericArray): Matrix4 {
+  getRotation(
+    result = [-0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0, -0],
+    scaleResult?: NumericArray
+  ): NumericArray {
     scaleResult = scaleResult || [-0, -0, -0];
     const scale = this.getScale(scaleResult);
     const inverseScale0 = 1 / scale[0];
@@ -437,9 +438,12 @@ export class Matrix4 extends Matrix {
    * @param scaleResult
    * @returns self
    */
-  getRotationMatrix3(scaleResult?: NumericArray): Matrix3;
+  getRotationMatrix3(scaleResult?: NumericArray): NumericArray;
   getRotationMatrix3<T extends NumericArray>(result: T, scaleResult?: NumericArray): T;
-  getRotationMatrix3(result = new Matrix3(), scaleResult?: NumericArray): Matrix3 {
+  getRotationMatrix3(
+    result = [-0, -0, -0, -0, -0, -0, -0, -0, -0],
+    scaleResult?: NumericArray
+  ): NumericArray {
     scaleResult = scaleResult || [-0, -0, -0];
     const scale = this.getScale(scaleResult);
     const inverseScale0 = 1 / scale[0];

--- a/modules/core/src/lib/gl-matrix.d.ts
+++ b/modules/core/src/lib/gl-matrix.d.ts
@@ -154,6 +154,11 @@ declare module 'gl-matrix/mat3' {
 declare module 'gl-matrix/mat4' {
   function determinant(a: Readonly<NumericArray>): number;
   function fromQuat<T extends NumericArray>(out: T, q: Readonly<NumericArray>): T;
+  function fromRotationTranslation<T extends NumericArray>(
+    out: T,
+    q: Readonly<NumericArray>,
+    v: Readonly<NumericArray>
+  ): T;
   function transpose<T extends NumericArray>(out: T, a: Readonly<NumericArray>): T;
   function invert<T extends NumericArray>(out: T, a: Readonly<NumericArray>): T;
   function getRotation<T extends NumericArray>(out: T, mat: Readonly<NumericArray>): T;

--- a/modules/core/test/classes/matrix4.spec.ts
+++ b/modules/core/test/classes/matrix4.spec.ts
@@ -2,7 +2,8 @@
 // MIT License
 
 /* eslint-disable max-statements */
-import {Matrix4, Vector3, config, configure} from '@math.gl/core';
+import {Matrix4, Matrix3, Quaternion, Vector3, config, configure} from '@math.gl/core';
+import {vec3, quat} from 'gl-matrix';
 import test from 'tape-promise/tape';
 import {tapeEquals, tapeEqualsEpsilon} from 'test/utils/tape-assertions';
 
@@ -43,7 +44,16 @@ test('Matrix4#fromQuaternion', (t) => {
 });
 
 test('Matrix4#fromTranslationQuaternion', (t) => {
-  tapeEquals(t, new Matrix4().fromTranslationQuaternion([0, 0, 0], [0, 0, 0, 1]), IDENTITY_MATRIX);
+  const translation = new Vector3(vec3.random([-0, -0, -0], 100 * Math.random()));
+  const quaternion = new Quaternion(quat.random([-0, -0, -0, -0]));
+
+  tapeEquals(
+    t,
+    new Matrix4().fromTranslationQuaternion(translation, quaternion),
+    new Matrix4()
+      .fromQuaternion(quaternion)
+      .multiplyLeft(new Matrix4().identity().translate(translation))
+  );
   t.end();
 });
 
@@ -164,6 +174,18 @@ test('Matrix4#getScale', (t) => {
   t.end();
 });
 
+test('Matrix4#getScaleAsVector3', (t) => {
+  const INPUT = INDICES_MATRIX;
+  const RESULT = new Vector3([3.7416573867739413, 10.488088481701515, 17.37814719698276]);
+
+  const scale = new Matrix4(INPUT).getScale(new Vector3());
+
+  tapeEquals(t, scale instanceof Vector3, true);
+  tapeEquals(t, scale, RESULT, 'getScale gave the right result');
+
+  t.end();
+});
+
 test('Matrix4#getRotation', (t) => {
   const INPUT = INDICES_MATRIX;
   const RESULT = [
@@ -173,6 +195,21 @@ test('Matrix4#getRotation', (t) => {
   ];
 
   const m = new Matrix4(INPUT).getRotation([...INDICES_MATRIX]);
+  tapeEquals(t, m, RESULT, 'getRotation gave the right result');
+
+  t.end();
+});
+
+test('Matrix4#getRotationAsMatrix4', (t) => {
+  const INPUT = INDICES_MATRIX;
+  const RESULT = new Matrix4([
+    0.2672612419124244, 0.19069251784911848, 0.17263060129453078, 0, 1.3363062095621219,
+    0.5720775535473555, 0.4028047363539052, 0, 2.4053511772118195, 0.9534625892455924,
+    0.6329788714132796, 0, 0, 0, 0, 1
+  ]);
+
+  const m = new Matrix4(INPUT).getRotation(new Matrix4(), [...INDICES_MATRIX]);
+  tapeEquals(t, m instanceof Matrix4, true);
   tapeEquals(t, m, RESULT, 'getRotation gave the right result');
 
   t.end();
@@ -192,11 +229,37 @@ test('Matrix4#getRotationMatrix3', (t) => {
   t.end();
 });
 
+test('Matrix4#getRotationMatrix3AsMatrix3', (t) => {
+  const INPUT = INDICES_MATRIX;
+  const RESULT = new Matrix3([
+    0.2672612419124244, 0.19069251784911848, 0.17263060129453078, 1.3363062095621219,
+    0.5720775535473555, 0.4028047363539052, 2.4053511772118195, 0.9534625892455924,
+    0.6329788714132796
+  ]);
+
+  const m = new Matrix4(INPUT).getRotationMatrix3(new Matrix3(), [...INDICES_MATRIX.slice(0, 9)]);
+  tapeEquals(t, m instanceof Matrix3, true);
+  tapeEquals(t, m, RESULT, 'getRotationMatrix3 gave the right result');
+
+  t.end();
+});
+
 test('Matrix4#getTranslation', (t) => {
   const INPUT = INDICES_MATRIX;
   const RESULT = [13, 14, 15];
 
   const m = new Matrix4(INPUT).getTranslation([0, 0, 0]);
+  tapeEquals(t, m, RESULT, 'getTranslation gave the right result');
+
+  t.end();
+});
+
+test('Matrix4#getTranslationAsVector3', (t) => {
+  const INPUT = INDICES_MATRIX;
+  const RESULT = new Vector3([13, 14, 15]);
+
+  const m = new Matrix4(INPUT).getTranslation(new Vector3());
+  tapeEquals(t, m instanceof Vector3, true);
   tapeEquals(t, m, RESULT, 'getTranslation gave the right result');
 
   t.end();

--- a/modules/core/test/classes/matrix4.spec.ts
+++ b/modules/core/test/classes/matrix4.spec.ts
@@ -42,6 +42,11 @@ test('Matrix4#fromQuaternion', (t) => {
   t.end();
 });
 
+test('Matrix4#fromTranslationQuaternion', (t) => {
+  tapeEquals(t, new Matrix4().fromTranslationQuaternion([0, 0, 0], [0, 0, 0, 1]), IDENTITY_MATRIX);
+  t.end();
+});
+
 test('Matrix4#from', (t) => {
   tapeEquals(t, new Matrix4().from(INDICES_MATRIX), INDICES_MATRIX);
   // tapeEquals(t, new Matrix4().from({x: 1, y: 2, z: 3, w: 4}), [1, 2, 3, 4]);


### PR DESCRIPTION
Added Matrix4.fromTranslationQuaternion.
And updated Matrix4.getScale, getTranslation, getRotation and getRotationMatrix3 to return same type as input. This allows the following kind of construct:
`new Matrix4().getRotationMatrix3().invert()`
